### PR TITLE
FakerBasedRandomizer: always use english locale if the no locale is p…

### DIFF
--- a/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/FakerBasedRandomizer.java
+++ b/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/FakerBasedRandomizer.java
@@ -40,11 +40,11 @@ public abstract class FakerBasedRandomizer<T> extends AbstractRandomizer<T> {
     protected Faker faker;
 
     protected FakerBasedRandomizer() {
-        faker = new Faker();
+        faker = new Faker(Locale.ENGLISH);
     }
 
     protected FakerBasedRandomizer(final long seed) {
-        this(seed, Locale.getDefault());
+        this(seed, Locale.ENGLISH);
     }
 
     protected FakerBasedRandomizer(final long seed, final Locale locale) {


### PR DESCRIPTION
…assed into the constructor (fixes #86, fixes #93)

The other option is to always try to create the faker with the default locale and only use the english locale if a `LocaleNotFoundException` occurs.