### PR TITLE
update java-faker version to 0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <junit.version>4.12</junit.version>
-        <faker.version>0.9</faker.version>
+        <faker.version>0.10</faker.version>
         <assertj.version>3.4.1</assertj.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <joda-time.version>2.9.3</joda-time.version>


### PR DESCRIPTION
This version of java-faker is android compatible and fixes a bug when a seed is used in combination with `regexify`.