### PR TITLE
Range based randomized annotation #130

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <spring-context.version>4.2.6.RELEASE</spring-context.version>
         <objenesis.version>2.2</objenesis.version>
         <fast-classpath-scanner.version>1.9.18</fast-classpath-scanner.version>
+        <commons-lang3.version>3.4</commons-lang3.version>
         <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
         <javax.el.version>2.2.6</javax.el.version>
         <mockito-core.version>1.10.19</mockito-core.version>
@@ -167,6 +168,11 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
                 <version>${spring-context.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.objenesis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <commons-lang3.version>3.4</commons-lang3.version>
         <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
         <javax.el.version>2.2.6</javax.el.version>
+        <jackson.version>2.7.4</jackson.version>
         <mockito-core.version>1.10.19</mockito-core.version>
         <junit-dataprovider.version>1.11.0</junit-dataprovider.version>
         <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
@@ -168,6 +169,11 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
                 <version>${spring-context.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/random-beans/pom.xml
+++ b/random-beans/pom.xml
@@ -82,6 +82,10 @@
             <artifactId>fast-classpath-scanner</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.16.8</version>

--- a/random-beans/pom.xml
+++ b/random-beans/pom.xml
@@ -86,6 +86,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.16.8</version>

--- a/random-beans/src/main/java/io/github/benas/randombeans/FieldDefinition.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/FieldDefinition.java
@@ -43,4 +43,9 @@ public class FieldDefinition<T, F> {
     private final Class<T> clazz;
 
 
+    public FieldDefinition(String name, Class<F> type, Class<T> clazz) {
+        this.name = name;
+        this.type = type;
+        this.clazz = clazz;
+    }
 }

--- a/random-beans/src/main/java/io/github/benas/randombeans/annotation/Randomizer.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/annotation/Randomizer.java
@@ -45,4 +45,7 @@ public @interface Randomizer {
      * @return the randomizer's class
      */
     Class<? extends io.github.benas.randombeans.api.Randomizer<?>> value();
+
+    String[] args() default { };
+
 }

--- a/random-beans/src/main/java/io/github/benas/randombeans/annotation/Randomizer.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/annotation/Randomizer.java
@@ -46,6 +46,5 @@ public @interface Randomizer {
      */
     Class<? extends io.github.benas.randombeans.api.Randomizer<?>> value();
 
-    String[] args() default { };
-
+    @RandomizerArgument RandomizerArgument[] args() default {};
 }

--- a/random-beans/src/main/java/io/github/benas/randombeans/annotation/RandomizerArgument.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/annotation/RandomizerArgument.java
@@ -1,0 +1,9 @@
+package io.github.benas.randombeans.annotation;
+
+/**
+ * Created by dkopel on 5/11/16.
+ */
+public @interface RandomizerArgument {
+    String value() default "";
+    Class type() default Object.class;
+}

--- a/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/AnnotationRandomizerRegistry.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/AnnotationRandomizerRegistry.java
@@ -67,6 +67,7 @@ public class AnnotationRandomizerRegistry implements RandomizerRegistry {
             Class<?> type = randomizer.value();
             String[] args = randomizer.args();
             try {
+                //return (Randomizer<?>) type.newInstance();
                 return ReflectionUtils.newInstance(type, args);
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create an instance of " + type.getName(), e);

--- a/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/AnnotationRandomizerRegistry.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/AnnotationRandomizerRegistry.java
@@ -27,6 +27,7 @@ package io.github.benas.randombeans.randomizers.registry;
 import io.github.benas.randombeans.annotation.Priority;
 import io.github.benas.randombeans.api.Randomizer;
 import io.github.benas.randombeans.api.RandomizerRegistry;
+import io.github.benas.randombeans.util.ReflectionUtils;
 
 import java.lang.reflect.Field;
 import java.util.logging.Level;
@@ -59,12 +60,14 @@ public class AnnotationRandomizerRegistry implements RandomizerRegistry {
      * @return the randomizer registered for the given field
      */
     @Override
+    @SuppressWarnings(value = "unchecked")
     public Randomizer<?> getRandomizer(Field field) {
         if (field.isAnnotationPresent(io.github.benas.randombeans.annotation.Randomizer.class)) {
             io.github.benas.randombeans.annotation.Randomizer randomizer = field.getAnnotation(io.github.benas.randombeans.annotation.Randomizer.class);
             Class<?> type = randomizer.value();
+            String[] args = randomizer.args();
             try {
-                return (Randomizer<?>) type.newInstance();
+                return ReflectionUtils.newInstance(type, args);
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create an instance of " + type.getName(), e);
             }

--- a/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/AnnotationRandomizerRegistry.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/AnnotationRandomizerRegistry.java
@@ -25,6 +25,7 @@
 package io.github.benas.randombeans.randomizers.registry;
 
 import io.github.benas.randombeans.annotation.Priority;
+import io.github.benas.randombeans.annotation.RandomizerArgument;
 import io.github.benas.randombeans.api.Randomizer;
 import io.github.benas.randombeans.api.RandomizerRegistry;
 import io.github.benas.randombeans.util.ReflectionUtils;
@@ -65,10 +66,11 @@ public class AnnotationRandomizerRegistry implements RandomizerRegistry {
         if (field.isAnnotationPresent(io.github.benas.randombeans.annotation.Randomizer.class)) {
             io.github.benas.randombeans.annotation.Randomizer randomizer = field.getAnnotation(io.github.benas.randombeans.annotation.Randomizer.class);
             Class<?> type = randomizer.value();
-            String[] args = randomizer.args();
+            RandomizerArgument[] arguments = randomizer.args();
+
             try {
                 //return (Randomizer<?>) type.newInstance();
-                return ReflectionUtils.newInstance(type, args);
+                return ReflectionUtils.newInstance(type, arguments);
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "Unable to create an instance of " + type.getName(), e);
             }

--- a/random-beans/src/main/java/io/github/benas/randombeans/util/Mapper.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/util/Mapper.java
@@ -1,0 +1,34 @@
+package io.github.benas.randombeans.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Created by dkopel on 5/11/16.
+ */
+public enum Mapper {
+    INSTANCE;
+
+    static private ObjectMapper objectMapper = new ObjectMapper();
+
+    ObjectMapper objectMapper() {
+        return objectMapper;
+    }
+
+    <T> T convertValue(Object obj, Class<T> type) {
+        return objectMapper.convertValue(obj, type);
+    }
+
+    <T> T convertValue(Object obj, TypeReference<T> typeReference) {
+        return objectMapper.convertValue(obj, typeReference);
+    }
+
+    <T> T convertValue(Object obj, JavaType javaType) {
+        return objectMapper.convertValue(obj, javaType);
+    }
+
+
+
+
+}

--- a/random-beans/src/main/java/io/github/benas/randombeans/util/ReflectionUtils.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/util/ReflectionUtils.java
@@ -285,10 +285,10 @@ public class ReflectionUtils {
         return (Randomizer<T>) clazz.newInstance();
     }
 
-    private static <T> T castPrimitive(Class<T> argType, String a) {
+    public static <T> T castPrimitive(Class<T> argType, String a) {
         if(ClassUtils.isPrimitiveOrWrapper(argType)) {
             if(argType.equals(String.class)) {
-                return (T) String.valueOf(a);
+                return (T) a;
             } else if(argType.equals(Long.class)) {
                 return (T) Long.valueOf(a);
             } else if(argType.equals(Integer.class)) {
@@ -299,9 +299,11 @@ public class ReflectionUtils {
                 return (T) Double.valueOf(a);
             } else if(argType.equals(Float.class)) {
                 return (T) Float.valueOf(a);
-            } else {
-                return (T) a;
             }
+        } else if(argType.equals(byte[].class)) {
+            return (T) a.getBytes();
+        } else {
+            return (T) a;
         }
         return null;
     }

--- a/random-beans/src/main/java/io/github/benas/randombeans/util/ReflectionUtils.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/util/ReflectionUtils.java
@@ -24,7 +24,9 @@
 
 package io.github.benas.randombeans.util;
 
+import io.github.benas.randombeans.api.Randomizer;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.ClassUtils;
 
 import java.lang.reflect.*;
 import java.util.*;
@@ -263,6 +265,46 @@ public class ReflectionUtils {
             }
         }
         return actualTypeArguments;
+    }
+
+    public static <T> Randomizer<T> newInstance(Class<T> clazz, String[] args) throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        if(args != null && args.length > 0) {
+            for(Constructor c : clazz.getConstructors()) {
+                if(c.getParameterCount() > 0 && c.getParameterCount() == args.length) {
+                    Object[] nArgs = new Object[args.length];
+                    Class[] argTypes = c.getParameterTypes();
+                    for(int x=0; x < args.length; x++) {
+                        Class<?> argType = argTypes[x];
+                        String a = args[x];
+                        nArgs[x] = castPrimitive(argType, a);
+                    }
+                    return (Randomizer<T>) c.newInstance(nArgs);
+                }
+            }
+            return (Randomizer<T>) clazz.newInstance();
+        }
+        return null;
+    }
+
+    private static <T> T castPrimitive(Class<T> argType, String a) {
+        if(ClassUtils.isPrimitiveOrWrapper(argType)) {
+            if(argType.equals(String.class)) {
+                return (T) String.valueOf(a);
+            } else if(argType.equals(Long.class)) {
+                return (T) Long.valueOf(a);
+            } else if(argType.equals(Integer.class)) {
+                return (T) Integer.valueOf(a);
+            } else if(argType.equals(Boolean.class)) {
+                return (T) Boolean.valueOf(a);
+            } else if(argType.equals(Double.class)) {
+                return (T) Double.valueOf(a);
+            } else if(argType.equals(Float.class)) {
+                return (T) Float.valueOf(a);
+            } else {
+                return (T) a;
+            }
+        }
+        return null;
     }
 
 }

--- a/random-beans/src/main/java/io/github/benas/randombeans/util/ReflectionUtils.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/util/ReflectionUtils.java
@@ -281,9 +281,8 @@ public class ReflectionUtils {
                     return (Randomizer<T>) c.newInstance(nArgs);
                 }
             }
-            return (Randomizer<T>) clazz.newInstance();
         }
-        return null;
+        return (Randomizer<T>) clazz.newInstance();
     }
 
     private static <T> T castPrimitive(Class<T> argType, String a) {

--- a/random-beans/src/test/java/io/github/benas/randombeans/RandomizerAnnotationTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/RandomizerAnnotationTest.java
@@ -24,6 +24,7 @@
 
 package io.github.benas.randombeans;
 
+import io.github.benas.randombeans.annotation.RandomizerArgument;
 import org.junit.Test;
 
 import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/DateRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/DateRangeRandomizerTest.java
@@ -24,6 +24,10 @@
 
 package io.github.benas.randombeans.randomizers.range;
 
+import io.github.benas.randombeans.EnhancedRandomBuilder;
+import io.github.benas.randombeans.annotation.Randomizer;
+import io.github.benas.randombeans.annotation.RandomizerArgument;
+import io.github.benas.randombeans.util.DateUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,6 +35,7 @@ import java.util.Date;
 
 import static io.github.benas.randombeans.randomizers.range.DateRangeRandomizer.aNewDateRangeRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
 
 public class DateRangeRandomizerTest extends AbstractRangeRandomizerTest<Date> {
 
@@ -93,6 +98,41 @@ public class DateRangeRandomizerTest extends AbstractRangeRandomizerTest<Date> {
 
         // Then
         assertThat(randomDate).isAfterOrEqualsTo(minDate);
+    }
+
+    public static class TestData {
+        public TestData(Date date) {
+            this.date = date;
+        }
+
+        @Randomizer(value=DateRangeRandomizer.class, args={
+                // 2016-01-10
+                @RandomizerArgument(value="1452384000000", type=Date.class),
+                // 2016-01-30
+                @RandomizerArgument(value="1454112000000", type=Date.class)
+        })
+        private Date date;
+
+        public Date getDate() {
+            return date;
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+    }
+
+    @Test
+    public void annotationShouldWorkWithRange() {
+        DateRangeRandomizerTest.TestData data = null;
+        for(int x=0; x < 10; x++) {
+            data = new EnhancedRandomBuilder().build().nextObject(DateRangeRandomizerTest.TestData.class);
+            System.out.println(data.getDate().toString());
+            then(data.getDate().getTime()).isBetween(
+                    1452384000000L,
+                    1454112000000L
+            );
+        }
     }
 
 }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/DateRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/DateRangeRandomizerTest.java
@@ -27,11 +27,18 @@ package io.github.benas.randombeans.randomizers.range;
 import io.github.benas.randombeans.EnhancedRandomBuilder;
 import io.github.benas.randombeans.annotation.Randomizer;
 import io.github.benas.randombeans.annotation.RandomizerArgument;
+import io.github.benas.randombeans.api.EnhancedRandom;
 import io.github.benas.randombeans.util.DateUtils;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
 import java.util.Date;
+import java.util.Locale;
 
 import static io.github.benas.randombeans.randomizers.range.DateRangeRandomizer.aNewDateRangeRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -107,9 +114,9 @@ public class DateRangeRandomizerTest extends AbstractRangeRandomizerTest<Date> {
 
         @Randomizer(value=DateRangeRandomizer.class, args={
                 // 2016-01-10
-                @RandomizerArgument(value="1452384000000", type=Date.class),
+                @RandomizerArgument(value="2016-01-10", type=Date.class),
                 // 2016-01-30
-                @RandomizerArgument(value="1454112000000", type=Date.class)
+                @RandomizerArgument(value="2016-01-30", type=Date.class)
         })
         private Date date;
 
@@ -123,14 +130,14 @@ public class DateRangeRandomizerTest extends AbstractRangeRandomizerTest<Date> {
     }
 
     @Test
-    public void annotationShouldWorkWithRange() {
+    public void annotationShouldWorkWithRange() throws Exception {
         DateRangeRandomizerTest.TestData data = null;
         for(int x=0; x < 10; x++) {
-            data = new EnhancedRandomBuilder().build().nextObject(DateRangeRandomizerTest.TestData.class);
-            System.out.println(data.getDate().toString());
+            data = EnhancedRandom.random(DateRangeRandomizerTest.TestData.class);
+
             then(data.getDate().getTime()).isBetween(
-                    1452384000000L,
-                    1454112000000L
+                    LocalDate.parse("2016-01-10").atStartOfDay().toEpochSecond(ZoneOffset.UTC)*1000,
+                    LocalDate.parse("2016-01-30").atStartOfDay().toEpochSecond(ZoneOffset.UTC)*1000
             );
         }
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/IntegerRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/IntegerRangeRandomizerTest.java
@@ -27,6 +27,7 @@ package io.github.benas.randombeans.randomizers.range;
 import io.github.benas.randombeans.EnhancedRandomBuilder;
 import io.github.benas.randombeans.annotation.Randomizer;
 import io.github.benas.randombeans.annotation.RandomizerArgument;
+import io.github.benas.randombeans.api.EnhancedRandom;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -103,7 +104,7 @@ public class IntegerRangeRandomizerTest extends AbstractRangeRandomizerTest<Inte
     public void annotationShouldWorkWithRange() {
         TestData data = null;
         for(int x=0; x < 10; x++) {
-            data = new EnhancedRandomBuilder().build().nextObject(TestData.class);
+            data = EnhancedRandom.random(TestData.class);
             then(data.getPrice()).isBetween(200, 500);
         }
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/IntegerRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/IntegerRangeRandomizerTest.java
@@ -26,6 +26,7 @@ package io.github.benas.randombeans.randomizers.range;
 
 import io.github.benas.randombeans.EnhancedRandomBuilder;
 import io.github.benas.randombeans.annotation.Randomizer;
+import io.github.benas.randombeans.annotation.RandomizerArgument;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -83,7 +84,10 @@ public class IntegerRangeRandomizerTest extends AbstractRangeRandomizerTest<Inte
             this.price = price;
         }
 
-        @Randomizer(value=IntegerRangeRandomizer.class, args={"200", "220"})
+        @Randomizer(value=IntegerRangeRandomizer.class, args={
+                @RandomizerArgument(value="200", type=Integer.class),
+                @RandomizerArgument(value="500", type=Integer.class)
+        })
         private int price;
 
         public void setPrice(int price) {

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/IntegerRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/IntegerRangeRandomizerTest.java
@@ -24,6 +24,8 @@
 
 package io.github.benas.randombeans.randomizers.range;
 
+import io.github.benas.randombeans.EnhancedRandomBuilder;
+import io.github.benas.randombeans.annotation.Randomizer;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -75,4 +77,31 @@ public class IntegerRangeRandomizerTest extends AbstractRangeRandomizerTest<Inte
 
         then(i).isEqualTo(7);
     }
+
+    public static class TestData {
+        public TestData(int price) {
+            this.price = price;
+        }
+
+        @Randomizer(value=IntegerRangeRandomizer.class, args={"200", "220"})
+        private int price;
+
+        public void setPrice(int price) {
+            this.price = price;
+        }
+
+        public int getPrice() {
+            return price;
+        }
+    }
+
+    @Test
+    public void annotationShouldWorkWithRange() {
+        TestData data = null;
+        for(int x=0; x < 10; x++) {
+            data = new EnhancedRandomBuilder().build().nextObject(TestData.class);
+            then(data.getPrice()).isBetween(200, 500);
+        }
+    }
+
 }

--- a/random-beans/src/test/java/io/github/benas/randombeans/util/ReflectionUtilsTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/util/ReflectionUtilsTest.java
@@ -77,5 +77,16 @@ public class ReflectionUtilsTest {
         assertThat(ReflectionUtils.isJdkBuiltIn(CustomList.class)).isFalse();
     }
 
+    @Test
+    public void testPrimitiveCast() {
+        assertThat(ReflectionUtils.castPrimitive(String.class, "test").equals("test"));
+        assertThat(ReflectionUtils.castPrimitive(byte[].class, "test").equals("test"));
+        assertThat(ReflectionUtils.castPrimitive(Integer.class, "10").equals(10));
+        assertThat(ReflectionUtils.castPrimitive(Long.class, "10").equals(10L));
+        assertThat(ReflectionUtils.castPrimitive(Boolean.class, "TRUE").equals(Boolean.TRUE));
+        assertThat(ReflectionUtils.castPrimitive(Double.class, "4.44").equals(4.44));
+        assertThat(ReflectionUtils.castPrimitive(Float.class, "4.44").equals(6/7));
+    }
+
     private class Dummy { }
 }

--- a/random-beans/src/test/java/io/github/benas/randombeans/util/ReflectionUtilsTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/util/ReflectionUtilsTest.java
@@ -77,16 +77,5 @@ public class ReflectionUtilsTest {
         assertThat(ReflectionUtils.isJdkBuiltIn(CustomList.class)).isFalse();
     }
 
-    @Test
-    public void testPrimitiveCast() {
-        assertThat(ReflectionUtils.castPrimitive(String.class, "test").equals("test"));
-        assertThat(ReflectionUtils.castPrimitive(byte[].class, "test").equals("test"));
-        assertThat(ReflectionUtils.castPrimitive(Integer.class, "10").equals(10));
-        assertThat(ReflectionUtils.castPrimitive(Long.class, "10").equals(10L));
-        assertThat(ReflectionUtils.castPrimitive(Boolean.class, "TRUE").equals(Boolean.TRUE));
-        assertThat(ReflectionUtils.castPrimitive(Double.class, "4.44").equals(4.44));
-        assertThat(ReflectionUtils.castPrimitive(Float.class, "4.44").equals(6/7));
-    }
-
     private class Dummy { }
 }


### PR DESCRIPTION
I came up with this. It's dynamic enough and provides the capacity to still use a single annotation. I added `common-lang3` because it has the `ConstructorUtils` (https://commons.apache.org/proper/commons-lang/javadocs/api-3.1/org/apache/commons/lang3/reflect/ConstructorUtils.html). 

For a first stab at it. It is functional with a test as well. If you pass no arguments then it just creates the default annotation. If there are a lot of constructors with different number of arguments and types then they aren't supported right now. I'm sure that the kind of approach that is used in the `BeanFactory` would handle this more cleanly.

Let me know if you have any problems or questions.

Thanks,
DBK