### PR TITLE
make max collection size configurable: the default 255 sometimes is too big for bigger objects having a lot of lists

### DIFF
--- a/random-beans/src/main/java/io/github/benas/randombeans/CollectionPopulator.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/CollectionPopulator.java
@@ -51,7 +51,7 @@ class CollectionPopulator {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     Collection<?> getRandomCollection(final Field field, final PopulatorContext context) {
-        int randomSize = enhancedRandom.nextInt(MAX_COLLECTION_SIZE);
+        int randomSize = collectionSize();
         Class<?> fieldType = field.getType();
         Type fieldGenericType = field.getGenericType();
         Collection collection;
@@ -75,6 +75,12 @@ class CollectionPopulator {
         }
         return collection;
 
+    }
+
+    /** make collections contain at least one item */
+    int collectionSize() {
+        int randomSize = 1 + enhancedRandom.nextInt(enhancedRandom.getMaxCollectionSize());
+        return randomSize;
     }
 
     Collection<?> getEmptyImplementationForCollectionInterface(final Class<?> collectionInterface) {

--- a/random-beans/src/main/java/io/github/benas/randombeans/EnhancedRandomBuilder.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/EnhancedRandomBuilder.java
@@ -50,6 +50,8 @@ public class EnhancedRandomBuilder {
 
     private long seed;
 
+    private int maxCollectionSize;
+
     /**
      * Create a new {@link EnhancedRandomBuilder}.
      */
@@ -136,6 +138,11 @@ public class EnhancedRandomBuilder {
         return this;
     }
 
+    public EnhancedRandomBuilder maxCollectionSize(final int maxSize) {
+        this.maxCollectionSize = maxSize;
+        return this;
+    }
+
     /**
      * Register a {@link RandomizerRegistry}.
      *
@@ -174,6 +181,7 @@ public class EnhancedRandomBuilder {
     private EnhancedRandomImpl setupEnhancedRandom(LinkedHashSet<RandomizerRegistry> registries) {
         EnhancedRandomImpl enhancedRandom = new EnhancedRandomImpl(registries);
         enhancedRandom.setSeed(seed);
+        enhancedRandom.setMaxCollectionSize(maxCollectionSize);
         enhancedRandom.setScanClasspathForConcreteTypes(scanClasspathForConcreteTypes);
         return enhancedRandom;
     }

--- a/random-beans/src/main/java/io/github/benas/randombeans/EnhancedRandomBuilder.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/EnhancedRandomBuilder.java
@@ -29,6 +29,7 @@ import io.github.benas.randombeans.api.Randomizer;
 import io.github.benas.randombeans.api.RandomizerRegistry;
 import io.github.benas.randombeans.randomizers.misc.SkipRandomizer;
 import io.github.benas.randombeans.randomizers.registry.CustomRandomizerRegistry;
+import io.github.benas.randombeans.util.Constants;
 
 import java.util.*;
 import java.util.function.Supplier;
@@ -50,7 +51,7 @@ public class EnhancedRandomBuilder {
 
     private long seed;
 
-    private int maxCollectionSize;
+    private int maxCollectionSize = Constants.MAX_COLLECTION_SIZE;
 
     /**
      * Create a new {@link EnhancedRandomBuilder}.

--- a/random-beans/src/main/java/io/github/benas/randombeans/EnhancedRandomImpl.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/EnhancedRandomImpl.java
@@ -29,6 +29,7 @@ import io.github.benas.randombeans.api.ObjectGenerationException;
 import io.github.benas.randombeans.api.Randomizer;
 import io.github.benas.randombeans.api.RandomizerRegistry;
 import io.github.benas.randombeans.randomizers.misc.EnumRandomizer;
+import io.github.benas.randombeans.util.Constants;
 
 import java.lang.reflect.Field;
 import java.util.List;
@@ -46,6 +47,8 @@ import static io.github.benas.randombeans.util.ReflectionUtils.*;
 class EnhancedRandomImpl extends EnhancedRandom {
 
     private long seed;
+
+    private int maxCollectionSize = Constants.MAX_COLLECTION_SIZE;
 
     private final FieldPopulator fieldPopulator;
 
@@ -168,5 +171,13 @@ class EnhancedRandomImpl extends EnhancedRandom {
     public void setSeed(final long seed) {
         super.setSeed(seed);
         this.seed = seed;
+    }
+
+    public int getMaxCollectionSize() {
+        return maxCollectionSize;
+    }
+
+    public void setMaxCollectionSize( int maxCollectionSize ) {
+        this.maxCollectionSize = maxCollectionSize;
     }
 }

--- a/random-beans/src/main/java/io/github/benas/randombeans/MapPopulator.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/MapPopulator.java
@@ -54,7 +54,7 @@ class MapPopulator {
 
     @SuppressWarnings("unchecked")
     Map<?, ?> getRandomMap(final Field field, final PopulatorContext context) {
-        int randomSize = enhancedRandom.nextInt(MAX_COLLECTION_SIZE);
+        int randomSize = collectionSize();
         Class<?> fieldType = field.getType();
         Type fieldGenericType = field.getGenericType();
         Map<Object, Object> map;
@@ -82,6 +82,12 @@ class MapPopulator {
             }
         }
         return map;
+    }
+
+    /** make collections contain at least one item */
+    int collectionSize() {
+        int randomSize = 1 + enhancedRandom.nextInt(enhancedRandom.getMaxCollectionSize());
+        return randomSize;
     }
 
     Map<?, ?> getEmptyImplementationForMapInterface(final Class<?> mapInterface) {

--- a/random-beans/src/main/java/io/github/benas/randombeans/util/Constants.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/util/Constants.java
@@ -44,7 +44,7 @@ public abstract class Constants {
     /**
      * Maximum collection size.
      */
-    public static final byte MAX_COLLECTION_SIZE = Byte.MAX_VALUE;
+    public static final int MAX_COLLECTION_SIZE = Byte.MAX_VALUE;
 
     /**
      * Maximum string size.

--- a/random-beans/src/test/java/io/github/benas/randombeans/CollectionPopulatorTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/CollectionPopulatorTest.java
@@ -35,14 +35,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static io.github.benas.randombeans.util.Constants.MAX_COLLECTION_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CollectionPopulatorTest {
 
-    private static final int SIZE = 2;
     private static final String STRING = "foo";
 
     @Mock
@@ -85,7 +83,7 @@ public class CollectionPopulatorTest {
     @Test
     public void typedInterfaceCollectionTypesMightBePopulated() throws Exception {
         // Given
-        when(enhancedRandom.nextInt(MAX_COLLECTION_SIZE)).thenReturn(SIZE);
+        when(enhancedRandom.nextInt(0)).thenReturn(1); // there will be 2 items (one always is generated, and we ensure "random" will return 1 when asked)
         when(enhancedRandom.doPopulateBean(String.class, context)).thenReturn(STRING);
         Field field = Foo.class.getDeclaredField("typedInterfaceList");
 
@@ -100,7 +98,7 @@ public class CollectionPopulatorTest {
     @Test
     public void typedConcreteCollectionTypesMightBePopulated() throws Exception {
         // Given
-        when(enhancedRandom.nextInt(MAX_COLLECTION_SIZE)).thenReturn(SIZE);
+        when(enhancedRandom.nextInt(0)).thenReturn(1); // there will be 2 items (one always is generated, and we ensure "random" will return 1 when asked)
         when(enhancedRandom.doPopulateBean(String.class, context)).thenReturn(STRING);
         Field field = Foo.class.getDeclaredField("typedConcreteList");
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/EnhancedRandomBuilderTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/EnhancedRandomBuilderTest.java
@@ -128,4 +128,14 @@ public class EnhancedRandomBuilderTest {
 
         assertThat(actual).isEqualTo(human);
     }
+
+    @Test
+    public void shouldConfigureCollectionSizeFromBuilder() {
+        enhancedRandomBuilder = aNewEnhancedRandomBuilder();
+
+        EnhancedRandom enhancedRandom = enhancedRandomBuilder.maxCollectionSize(42).build();
+
+        assertThat(((EnhancedRandomImpl)enhancedRandom).getMaxCollectionSize()).isEqualTo(42);
+    }
+
 }


### PR DESCRIPTION
If you are randomizing a large object hierarchy, the default list size might be killing you. Sometimes you just need a few small lists here and there (such as, if you will be serializing the randomized objects as part of test).
Use the new config option as:

EnhancedRandom enhancedRandom = EnhancedRandomBuilder.aNewEnhancedRandomBuilder().maxCollectionSize( 5 ).build();

Now your randomized collections will have max 5 items. Also this ensures the collection has at least one item created - so that you can be sure some code path is not skipped.