### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <assertj.version>3.5.1</assertj.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
         <joda-time.version>2.9.4</joda-time.version>
-        <spring-context.version>4.3.0.RELEASE</spring-context.version>
+        <spring-context.version>4.3.1.RELEASE</spring-context.version>
         <objenesis.version>2.4</objenesis.version>
         <fast-classpath-scanner.version>1.10.4</fast-classpath-scanner.version>
         <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <joda-time.version>2.9.4</joda-time.version>
         <spring-context.version>4.3.0.RELEASE</spring-context.version>
         <objenesis.version>2.4</objenesis.version>
-        <fast-classpath-scanner.version>1.10.3</fast-classpath-scanner.version>
+        <fast-classpath-scanner.version>1.10.4</fast-classpath-scanner.version>
         <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
         <javax.el.version>2.2.6</javax.el.version>
         <jackson.version>2.7.5</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <fast-classpath-scanner.version>1.10.4</fast-classpath-scanner.version>
         <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
         <javax.el.version>2.2.6</javax.el.version>
-        <jackson.version>2.7.5</jackson.version>
+        <jackson.version>2.8.0</jackson.version>
         <mockito-core.version>1.10.19</mockito-core.version>
         <junit-dataprovider.version>1.11.0</junit-dataprovider.version>
         <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>


### PR DESCRIPTION
looks like the last fast-classpath-scanner version did not increase, but decrease performance: https://github.com/lukehutch/fast-classpath-scanner/commit/0b25528b5a7d56c888fb62e1ed01c565e78cf058