### PR TITLE
Support for method based proxies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <joda-time.version>2.9.4</joda-time.version>
         <spring-context.version>4.3.1.RELEASE</spring-context.version>
         <objenesis.version>2.4</objenesis.version>
+        <byte-buddy.version>1.4.18</byte-buddy.version>
         <fast-classpath-scanner.version>1.93.0</fast-classpath-scanner.version>
         <hibernate-validator.version>5.2.4.Final</hibernate-validator.version>
         <javax.el.version>2.2.6</javax.el.version>
@@ -184,6 +185,11 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-context</artifactId>
                 <version>${spring-context.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>

--- a/random-beans/pom.xml
+++ b/random-beans/pom.xml
@@ -86,6 +86,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.16.8</version>

--- a/random-beans/src/main/java/io/github/benas/randombeans/EnhancedRandomImpl.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/EnhancedRandomImpl.java
@@ -57,14 +57,18 @@ class EnhancedRandomImpl extends EnhancedRandom {
 
     private final FieldExclusionChecker fieldExclusionChecker;
 
-    EnhancedRandomImpl(final Set<RandomizerRegistry> registries) {
-        objectFactory = new ObjectFactory();
+    EnhancedRandomImpl(final Set<RandomizerRegistry> registries, ProxyRegistry proxyRegistry) {
+        objectFactory = new ObjectFactory(proxyRegistry);
         randomizerProvider = new RandomizerProvider(registries);
         arrayPopulator = new ArrayPopulator(this, randomizerProvider);
         collectionPopulator = new CollectionPopulator(this, objectFactory);
         mapPopulator = new MapPopulator(this, objectFactory);
         fieldPopulator = new FieldPopulator(this, randomizerProvider, arrayPopulator, collectionPopulator, mapPopulator);
         fieldExclusionChecker = new FieldExclusionChecker();
+    }
+
+    EnhancedRandomImpl(final Set<RandomizerRegistry> registries) {
+        this(registries, null);
     }
 
     @Override
@@ -137,6 +141,7 @@ class EnhancedRandomImpl extends EnhancedRandom {
             return (T) mapPopulator.getEmptyImplementationForMapInterface(type);
         }
         return null;
+
     }
 
     private <T> void populateFields(final List<Field> fields, final T result, final PopulatorContext context) throws IllegalAccessException {

--- a/random-beans/src/main/java/io/github/benas/randombeans/FieldDefinition.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/FieldDefinition.java
@@ -71,4 +71,20 @@ public class FieldDefinition<T, F> {
         this.clazz = clazz;
         this.annotations = annotations;
     }
+
+    public String getName() {
+        return name;
+    }
+
+    public Class<F> getType() {
+        return type;
+    }
+
+    public Class<T> getClazz() {
+        return clazz;
+    }
+
+    public Set<Class<? extends Annotation>> getAnnotations() {
+        return annotations;
+    }
 }

--- a/random-beans/src/main/java/io/github/benas/randombeans/ProxyRegistryImpl.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/ProxyRegistryImpl.java
@@ -1,0 +1,52 @@
+/**
+ * The MIT License
+ *
+ *   Copyright (c) 2016, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package io.github.benas.randombeans;
+
+import io.github.benas.randombeans.api.ProxyRegistry;
+import net.bytebuddy.dynamic.DynamicType.Unloaded;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by dkopel on 8/11/16.
+ */
+public class ProxyRegistryImpl implements ProxyRegistry {
+    Map<Class<?>, Unloaded<?>> proxies = new HashMap();
+
+    @Override
+    public void proxy(Class<?> type, Unloaded<?> unloadedProxy) {
+        proxies.put(type, unloadedProxy);
+    }
+
+    @Override
+    public <T> Unloaded<T> getProxy(Class<T> type) {
+        return (Unloaded<T>) proxies.get(type);
+    }
+
+    @Override
+    public Boolean hasProxy(Class<?> type) {
+        return proxies.containsKey(type);
+    }
+}

--- a/random-beans/src/main/java/io/github/benas/randombeans/api/EnhancedRandomParameters.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/api/EnhancedRandomParameters.java
@@ -78,6 +78,62 @@ public class EnhancedRandomParameters {
         this.timeRange = new Range<>(min, max);
     }
 
+    public void setSeed(long seed) {
+        this.seed = seed;
+    }
+
+    public void setMaxCollectionSize(int maxCollectionSize) {
+        this.maxCollectionSize = maxCollectionSize;
+    }
+
+    public void setMaxStringLength(int maxStringLength) {
+        this.maxStringLength = maxStringLength;
+    }
+
+    public void setCharset(Charset charset) {
+        this.charset = charset;
+    }
+
+    public void setScanClasspathForConcreteTypes(boolean scanClasspathForConcreteTypes) {
+        this.scanClasspathForConcreteTypes = scanClasspathForConcreteTypes;
+    }
+
+    public void setOverrideDefaultInitialization(boolean overrideDefaultInitialization) {
+        this.overrideDefaultInitialization = overrideDefaultInitialization;
+    }
+
+    public long getSeed() {
+        return seed;
+    }
+
+    public int getMaxCollectionSize() {
+        return maxCollectionSize;
+    }
+
+    public int getMaxStringLength() {
+        return maxStringLength;
+    }
+
+    public Charset getCharset() {
+        return charset;
+    }
+
+    public boolean isScanClasspathForConcreteTypes() {
+        return scanClasspathForConcreteTypes;
+    }
+
+    public boolean isOverrideDefaultInitialization() {
+        return overrideDefaultInitialization;
+    }
+
+    public Range<LocalDate> getDateRange() {
+        return dateRange;
+    }
+
+    public Range<LocalTime> getTimeRange() {
+        return timeRange;
+    }
+
     @Data
     public static class Range<T> {
         private T min;

--- a/random-beans/src/main/java/io/github/benas/randombeans/api/ProxyRegistry.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/api/ProxyRegistry.java
@@ -1,0 +1,35 @@
+/**
+ * The MIT License
+ *
+ *   Copyright (c) 2016, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package io.github.benas.randombeans.api;
+
+import net.bytebuddy.dynamic.DynamicType.Unloaded;
+
+/**
+ * Created by dkopel on 8/11/16.
+ */
+public interface ProxyRegistry {
+    void proxy(Class<?> type, Unloaded<?> unloadedProxy);
+    <T> Unloaded<T> getProxy(final Class<T> type);
+    Boolean hasProxy(final Class<?> type);
+}

--- a/random-beans/src/test/java/io/github/benas/randombeans/ObjectFactoryTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/ObjectFactoryTest.java
@@ -23,9 +23,21 @@
  */
 package io.github.benas.randombeans;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.benas.randombeans.api.ProxyRegistry;
+import io.github.benas.randombeans.beans.Person;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.ClassFileVersion;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.DelayQueue;
@@ -73,6 +85,46 @@ public class ObjectFactoryTest {
     @Test(expected = UnsupportedOperationException.class)
     public void delayQueueShouldBeRejected() {
         objectFactory.createEmptyCollectionForType(DelayQueue.class, INITIAL_CAPACITY);
+    }
+
+    private String name = null;
+
+    public class NameC {
+        public String getEmail() {
+            return name;
+        }
+    }
+
+    @Test
+    public void proxyTest() throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ProxyRegistry proxyRegistry = new ProxyRegistryImpl();
+        name = "tom";
+        DynamicType.Unloaded<? extends Person> bc = new ByteBuddy(ClassFileVersion.JAVA_V8)
+                .subclass(Person.class)
+                .method(ElementMatchers.named("getName"))
+                .intercept(MethodDelegation.to(new NameC()))
+                .make();
+        proxyRegistry.proxy(Person.class, bc);
+        objectFactory = new ObjectFactory(proxyRegistry);
+
+        Person b = objectFactory.createInstance(Person.class);
+
+        b.setName("ronald");
+
+        Assert.assertEquals(name, b.getName());
+
+        String bs = objectMapper.writeValueAsString(b);
+
+        Class<? extends Person> bbc = bc.load(
+                getClass().getClassLoader(),
+                ClassLoadingStrategy.Default.WRAPPER
+        ).getLoaded();
+        Person bb = objectMapper.readValue(bs, bbc);
+        name = "john";
+
+        bb.setName("donald");
+        Assert.assertEquals(name, bb.getName());
     }
 
     private abstract class AbstractFoo {


### PR DESCRIPTION
I added in support for the user to use a byte-buddy proxy for a class instantiation instead of just `newInstance` or objenesis. As seen my unit test, the proxy leaves things open to intercept the method not just the field. I have not yet added in this support yet. Theoretically we would have a `registerRandomizer(Method method, Randomizer<?> randomizer)` type thing. I am doing this on my library right now but would soon add that functionality to RB as well.

Enjoy!
