### PR TITLE
Add support for BigDecimal scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ If you have any question, suggestion, or feedback, do not hesitate to use the [G
 * [Vincent Potucek](https://github.com/punkratz312)
 * [Lucas Andersson](https://github.com/LucasAndersson)
 * [euZebe](https://github.com/euzebe)
+* [Petromir Dzhunev](https://github.com/petromir)
 
 Thank you all for your contributions!
 

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,10 @@
             <name>euZebe</name>
             <url>https://github.com/euzebe</url>
         </contributor>
+        <contributor>
+            <name>Petromir Dzhunev</name>
+            <url>https://github.com/petromir</url>
+        </contributor>
     </contributors>
 
     <dependencyManagement>

--- a/random-beans/src/main/java/io/github/benas/randombeans/randomizers/number/BigDecimalRandomizer.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/randomizers/number/BigDecimalRandomizer.java
@@ -26,6 +26,7 @@ package io.github.benas.randombeans.randomizers.number;
 import io.github.benas.randombeans.api.Randomizer;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 /**
  * Generate a random {@link BigDecimal}.
@@ -35,6 +36,7 @@ import java.math.BigDecimal;
 public class BigDecimalRandomizer implements Randomizer<BigDecimal> {
 
     private final DoubleRandomizer delegate;
+    private Integer scale;
 
     /**
      * Create a new {@link BigDecimalRandomizer}.
@@ -50,6 +52,16 @@ public class BigDecimalRandomizer implements Randomizer<BigDecimal> {
      */
     public BigDecimalRandomizer(final long seed) {
         delegate = new DoubleRandomizer(seed);
+    }
+
+    /**
+     * Create a new {@link BigDecimalRandomizer}. The default rounding mode is {@link RoundingMode#HALF_UP}.
+     *
+     * @param scale of the {@code BigDecimal} value to be returned.
+     */
+    public BigDecimalRandomizer(final Integer scale) {
+        delegate = new DoubleRandomizer();
+        this.scale = scale;
     }
 
     /**
@@ -70,9 +82,23 @@ public class BigDecimalRandomizer implements Randomizer<BigDecimal> {
     public static BigDecimalRandomizer aNewBigDecimalRandomizer(final long seed) {
         return new BigDecimalRandomizer(seed);
     }
-    
+
+    /**
+     * Create a new {@link BigDecimalRandomizer}.The default rounding mode is {@link RoundingMode#HALF_UP}.
+     *
+     * @param scale of the {@code BigDecimal} value to be returned.
+     * @return a new {@link BigDecimalRandomizer}.
+     */
+    public static BigDecimalRandomizer aNewBigDecimalRandomizer(final Integer scale) {
+        return new BigDecimalRandomizer(scale);
+    }
+
     @Override
     public BigDecimal getRandomValue() {
-        return new BigDecimal(delegate.getRandomValue());
+        BigDecimal randomValue = new BigDecimal(delegate.getRandomValue());
+        if (scale != null) {
+            randomValue = randomValue.setScale(this.scale, RoundingMode.HALF_UP);
+        }
+        return randomValue;
     }
 }

--- a/random-beans/src/main/java/io/github/benas/randombeans/randomizers/range/BigDecimalRangeRandomizer.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/randomizers/range/BigDecimalRangeRandomizer.java
@@ -26,6 +26,7 @@ package io.github.benas.randombeans.randomizers.range;
 import io.github.benas.randombeans.api.Randomizer;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 /**
  * Generate a random {@link BigDecimal} in the given range.
@@ -35,6 +36,7 @@ import java.math.BigDecimal;
 public class BigDecimalRangeRandomizer implements Randomizer<BigDecimal> {
 
     private final LongRangeRandomizer delegate;
+    private Integer scale;
 
     /**
      * Create a new {@link BigDecimalRangeRandomizer}.
@@ -55,6 +57,18 @@ public class BigDecimalRangeRandomizer implements Randomizer<BigDecimal> {
      */
     public BigDecimalRangeRandomizer(final Long min, final Long max, final long seed) {
         delegate = new LongRangeRandomizer(min, max, seed);
+    }
+
+    /**
+     * Create a new {@link BigDecimalRangeRandomizer}. The default rounding mode is {@link RoundingMode#HALF_UP}.
+     *
+     * @param min   min value
+     * @param max   max value
+     * @param scale of the {@code BigDecimal} value to be returned.
+     */
+    public BigDecimalRangeRandomizer(final Long min, final Long max, final Integer scale) {
+        delegate = new LongRangeRandomizer(min, max);
+        this.scale = scale;
     }
 
     /**
@@ -80,8 +94,24 @@ public class BigDecimalRangeRandomizer implements Randomizer<BigDecimal> {
         return new BigDecimalRangeRandomizer(min, max, seed);
     }
 
+    /**
+     * Create a new {@link BigDecimalRangeRandomizer}.The default rounding mode is {@link RoundingMode#HALF_UP}.
+     *
+     * @param min   min value
+     * @param max   max value
+     * @param scale of the {@code BigDecimal} value to be returned.
+     * @return a new {@link BigDecimalRangeRandomizer}.
+     */
+    public static BigDecimalRangeRandomizer aNewBigDecimalRangeRandomizer(final Long min, final Long max, final Integer scale) {
+        return new BigDecimalRangeRandomizer(min, max, scale);
+    }
+
     @Override
     public BigDecimal getRandomValue() {
-        return new BigDecimal(delegate.getRandomValue());
+        BigDecimal randomValue = new BigDecimal(delegate.getRandomValue());
+        if (scale != null) {
+            randomValue = randomValue.setScale(this.scale, RoundingMode.HALF_UP);
+        }
+        return randomValue;
     }
 }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/number/BigDecimalRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/number/BigDecimalRandomizerTest.java
@@ -1,0 +1,36 @@
+package io.github.benas.randombeans.randomizers.number;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static io.github.benas.randombeans.randomizers.number.BigDecimalRandomizer.aNewBigDecimalRandomizer;
+import static org.assertj.core.api.BDDAssertions.then;
+
+public class BigDecimalRandomizerTest extends AbstractRandomizerTest<BigDecimal> {
+
+    @Test
+    public void generatedValueShouldHaveProvidedPositiveScale() {
+        // given
+        Integer scale = 1;
+        BigDecimalRandomizer bigDecimalRandomizer = aNewBigDecimalRandomizer(scale);
+
+        // when
+        BigDecimal bigDecimal = bigDecimalRandomizer.getRandomValue();
+
+        then(bigDecimal.scale()).isEqualTo(scale);
+    }
+
+    @Test
+    public void generatedValueShouldHaveProvidedNegativeScale() {
+        // given
+        Integer scale = -1;
+        BigDecimalRandomizer bigDecimalRangeRandomizer = aNewBigDecimalRandomizer(scale);
+
+        // when
+        BigDecimal bigDecimal = bigDecimalRangeRandomizer.getRandomValue();
+
+        then(bigDecimal.scale()).isEqualTo(scale);
+    }
+}

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/BigDecimalRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/BigDecimalRangeRandomizerTest.java
@@ -72,10 +72,34 @@ public class BigDecimalRangeRandomizerTest extends AbstractRangeRandomizerTest<B
     public void shouldAlwaysGenerateTheSameValueForTheSameSeed() {
         // given
         BigDecimalRangeRandomizer bigDecimalRangeRandomizer = aNewBigDecimalRangeRandomizer(min, max, SEED);
-        
+
         // when
         BigDecimal bigDecimal = bigDecimalRangeRandomizer.getRandomValue();
 
         then(bigDecimal).isEqualTo(new BigDecimal("7"));
+    }
+
+    @Test
+    public void generatedValueShouldHaveProvidedPositiveScale() {
+        // given
+        Integer scale = 2;
+        BigDecimalRangeRandomizer bigDecimalRangeRandomizer = aNewBigDecimalRangeRandomizer(min, max, scale);
+
+        // when
+        BigDecimal bigDecimal = bigDecimalRangeRandomizer.getRandomValue();
+
+        then(bigDecimal.scale()).isEqualTo(scale);
+    }
+
+    @Test
+    public void generatedValueShouldHaveProvidedNegativeScale() {
+        // given
+        Integer scale = -2;
+        BigDecimalRangeRandomizer bigDecimalRangeRandomizer = aNewBigDecimalRangeRandomizer(min, max, scale);
+
+        // when
+        BigDecimal bigDecimal = bigDecimalRangeRandomizer.getRandomValue();
+
+        then(bigDecimal.scale()).isEqualTo(scale);
     }
 }


### PR DESCRIPTION
The dafault rounding mode is HALF_UP. That could be changed easily if such need occurs.
There is a new test BigDecimalRandomizerTest, which doesn't include already tested cases in NumberRandomizersTest 