### PR TITLE
If a class has no default constructor, try to force access to a non-p…

### DIFF
--- a/random-beans/src/main/java/io/github/benas/randombeans/ObjectFactory.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/ObjectFactory.java
@@ -28,6 +28,7 @@ import org.objenesis.ObjenesisStd;
 
 import io.github.benas.randombeans.api.ObjectGenerationException;
 
+import java.lang.reflect.Constructor;
 import java.util.Collection;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.DelayQueue;
@@ -69,7 +70,11 @@ class ObjectFactory {
 
     private <T> T createNewInstance(final Class<T> type) {
         try {
-            return type.newInstance();
+            Constructor<T> noArgConstructor = type.getDeclaredConstructor();
+            if (!noArgConstructor.isAccessible()) {
+                noArgConstructor.setAccessible(true);
+            }
+            return noArgConstructor.newInstance();
         } catch (Exception exception) {
             return objenesis.newInstance(type);
         }

--- a/random-beans/src/test/java/io/github/benas/randombeans/FieldExclusionTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/FieldExclusionTest.java
@@ -284,6 +284,17 @@ public class FieldExclusionTest {
     }
 
     @Test
+    public void whenFieldIsExcluded_thenItsInlineInitializationShouldBeUsedAsIs_EvenIfBeanHasNoPublicConstructor() {
+        enhancedRandom = aNewEnhancedRandomBuilder()
+            .exclude(new FieldDefinition<>("myList", List.class, InlineInitializationBeanPrivateConstructor.class))
+            .build();
+
+        InlineInitializationBeanPrivateConstructor bean = enhancedRandom.nextObject(InlineInitializationBeanPrivateConstructor.class);
+
+        assertThat(bean.getMyList()).isEmpty();
+    }
+
+    @Test
     public void fieldsExcludedWithOneModifierShouldNotBePopulated() {
         // given
         enhancedRandom = aNewEnhancedRandomBuilder()
@@ -340,4 +351,13 @@ public class FieldExclusionTest {
         }
     }
 
+    public static class InlineInitializationBeanPrivateConstructor {
+        private List<String> myList = new ArrayList<>();
+
+        public List<String> getMyList() {
+            return myList;
+        }
+
+        private InlineInitializationBeanPrivateConstructor() {}
+    }
 }


### PR DESCRIPTION
…ublic no-arg-constructor before using objenesis to create an instance.

This allows excluded fields of classes with no default constructor to be initialized with their default value (fixes #246).