### PR TITLE
Fix TODO in reflection utils

### DIFF
--- a/random-beans/src/main/java/io/github/benas/randombeans/PrimitiveEnum.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/PrimitiveEnum.java
@@ -1,0 +1,57 @@
+/**
+ * The MIT License
+ *
+ *   Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+package io.github.benas.randombeans;
+
+/**
+ * Wrapper for primitive TYPE values and their classes.
+ *
+ * @author Sam Van Overmeire
+ */
+public enum PrimitiveEnum {
+
+    BYTE(Byte.TYPE, Byte.class),
+    SHORT(Short.TYPE, Short.class),
+    INTEGER(Integer.TYPE, Integer.class),
+    LONG(Long.TYPE, Long.class),
+    FLOAT(Float.TYPE, Float.class),
+    DOUBLE(Double.TYPE, Double.class),
+    BOOLEAN(Boolean.TYPE, Boolean.class),
+    CHARACTER(Character.TYPE, Character.class);
+
+    private Class<?> type;
+    private Class<?> clazz;
+
+    PrimitiveEnum(Class<?> type, Class<?> clazz) {
+        this.type = type;
+        this.clazz = clazz;
+    }
+
+    public Class<?> getType() {
+        return type;
+    }
+
+    public Class<?> getClazz() {
+        return clazz;
+    }
+}

--- a/random-beans/src/main/java/io/github/benas/randombeans/util/ReflectionUtils.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/util/ReflectionUtils.java
@@ -24,6 +24,7 @@
 package io.github.benas.randombeans.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.benas.randombeans.PrimitiveEnum;
 import io.github.benas.randombeans.annotation.RandomizerArgument;
 import io.github.benas.randombeans.api.ObjectGenerationException;
 import io.github.benas.randombeans.api.Randomizer;
@@ -120,31 +121,12 @@ public class ReflectionUtils {
      * @return the wrapper type of the given primitive type
      */
     public Class<?> getWrapperType(Class<?> primitiveType) {
-        // FIXME is there a better way to do this?
-        if (Byte.TYPE.equals(primitiveType)) {
-            return Byte.class;
+        for(PrimitiveEnum p : PrimitiveEnum.values()) {
+            if(p.getType().equals(primitiveType)) {
+                return p.getClazz();
+            }
         }
-        if (Short.TYPE.equals(primitiveType)) {
-            return Short.class;
-        }
-        if (Integer.TYPE.equals(primitiveType)) {
-            return Integer.class;
-        }
-        if (Long.TYPE.equals(primitiveType)) {
-            return Long.class;
-        }
-        if (Double.TYPE.equals(primitiveType)) {
-            return Double.class;
-        }
-        if (Float.TYPE.equals(primitiveType)) {
-            return Float.class;
-        }
-        if (Boolean.TYPE.equals(primitiveType)) {
-            return Boolean.class;
-        }
-        if (Character.TYPE.equals(primitiveType)) {
-            return Character.class;
-        }
+
         return primitiveType; // if not primitive, return it as is
     }
 


### PR DESCRIPTION
This might solve the TODO in reflection utils, by creating an enum that wraps around the stuff you need in the getWrapperType enum. 

Looks a lot cleaner at any rate.