### PR TITLE
partial migration to junit 5 and junit-dataprovider 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <lombok.version>1.16.18</lombok.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>5.0.2</junit.version>
         <faker.version>0.14</faker.version>
         <assertj.version>3.8.0</assertj.version>
         <validation-api.version>1.1.0.Final</validation-api.version>
@@ -33,8 +33,8 @@
         <javax.el.version>2.2.6</javax.el.version>
         <jackson.version>2.9.2</jackson.version>
         <mockito-core.version>2.11.0</mockito-core.version>
-        <junit-dataprovider.version>1.13.1</junit-dataprovider.version>
-        <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
+        <junit-dataprovider.version>2.0</junit-dataprovider.version>
+        <maven-surefire-plugin.version>2.19</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-cobertura-plugin.version>2.7</maven-cobertura-plugin.version>
         <maven-coveralls-plugin.version>4.3.0</maven-coveralls-plugin.version>
@@ -243,9 +243,14 @@
                 <version>${faker.version}</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
                 <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>4.12.2</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>
@@ -258,8 +263,8 @@
                 <version>${mockito-core.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.tngtech.java</groupId>
-                <artifactId>junit-dataprovider</artifactId>
+                <groupId>com.tngtech.junit.dataprovider</groupId>
+                <artifactId>junit-jupiter-dataprovider</artifactId>
                 <version>${junit-dataprovider.version}</version>
             </dependency>
         </dependencies>
@@ -293,6 +298,18 @@
                         </includes>
                         <reportFormat>html</reportFormat>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-surefire-provider</artifactId>
+                            <version>1.0.2</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.junit.jupiter</groupId>
+                            <artifactId>junit-jupiter-engine</artifactId>
+                            <version>${junit.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/random-beans-jodatime/pom.xml
+++ b/random-beans-jodatime/pom.xml
@@ -58,8 +58,8 @@
             <artifactId>joda-time</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -73,8 +73,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.tngtech.java</groupId>
-            <artifactId>junit-dataprovider</artifactId>
+            <groupId>com.tngtech.junit.dataprovider</groupId>
+            <artifactId>junit-jupiter-dataprovider</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/random-beans-jodatime/src/test/java/io/github/benas/randombeans/randomizers/jodatime/JodaTimeDateTimeRandomizerTest.java
+++ b/random-beans-jodatime/src/test/java/io/github/benas/randombeans/randomizers/jodatime/JodaTimeDateTimeRandomizerTest.java
@@ -24,7 +24,7 @@
 package io.github.benas.randombeans.randomizers.jodatime;
 
 import org.joda.time.DateTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static io.github.benas.randombeans.randomizers.jodatime.JodaTimeDateTimeRandomizer.aNewJodaTimeDateTimeRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/random-beans-jodatime/src/test/java/io/github/benas/randombeans/randomizers/jodatime/JodaTimeRandomizersTest.java
+++ b/random-beans-jodatime/src/test/java/io/github/benas/randombeans/randomizers/jodatime/JodaTimeRandomizersTest.java
@@ -37,16 +37,16 @@ import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 import org.joda.time.LocalTime;
 import org.joda.time.Period;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.UseDataProviderExtension;
 
 import io.github.benas.randombeans.api.Randomizer;
 
-@RunWith(DataProviderRunner.class)
+@ExtendWith(UseDataProviderExtension.class)
 public class JodaTimeRandomizersTest extends AbstractJodaTimeRandomizerTest {
 
     @DataProvider
@@ -61,7 +61,7 @@ public class JodaTimeRandomizersTest extends AbstractJodaTimeRandomizerTest {
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateRandomizers")
     public void generatedTimeShouldNotBeNull(Randomizer<?> randomizer) {
         // when
@@ -82,7 +82,7 @@ public class JodaTimeRandomizersTest extends AbstractJodaTimeRandomizerTest {
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateSeededRandomizersAndTheirExpectedValues")
     public void shouldGenerateTheSameValueForTheSameSeed(Randomizer<?> randomizer, Object expected) {
         //when

--- a/random-beans-jodatime/src/test/java/io/github/benas/randombeans/randomizers/jodatime/JodaTimeRangeRandomizersTest.java
+++ b/random-beans-jodatime/src/test/java/io/github/benas/randombeans/randomizers/jodatime/JodaTimeRangeRandomizersTest.java
@@ -30,13 +30,17 @@ import static io.github.benas.randombeans.randomizers.jodatime.range.JodaTimeLoc
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 
-import org.joda.time.*;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.joda.time.LocalDateTime;
+import org.joda.time.LocalTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.UseDataProviderExtension;
 
 import io.github.benas.randombeans.api.Randomizer;
 import io.github.benas.randombeans.randomizers.jodatime.range.JodaTimeDateTimeRangeRandomizer;
@@ -44,7 +48,7 @@ import io.github.benas.randombeans.randomizers.jodatime.range.JodaTimeLocalDateR
 import io.github.benas.randombeans.randomizers.jodatime.range.JodaTimeLocalDateTimeRangeRandomizer;
 import io.github.benas.randombeans.randomizers.jodatime.range.JodaTimeLocalTimeRangeRandomizer;
 
-@RunWith(DataProviderRunner.class)
+@ExtendWith(UseDataProviderExtension.class)
 public class JodaTimeRangeRandomizersTest extends AbstractJodaTimeRandomizerTest {
 
     @DataProvider
@@ -57,7 +61,7 @@ public class JodaTimeRangeRandomizersTest extends AbstractJodaTimeRandomizerTest
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateRandomizers")
     public void generatedTimeShouldNotBeNull(Randomizer<?> randomizer) {
         // when
@@ -84,7 +88,7 @@ public class JodaTimeRangeRandomizersTest extends AbstractJodaTimeRandomizerTest
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateRandomizersAndMinMax")
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public void shouldGenerateValuesBetweenMinAndMax(Randomizer<Comparable> randomizer, Comparable min, Comparable max) {

--- a/random-beans-jodatime/src/test/java/io/github/benas/randombeans/randomizers/jodatime/JodaTimeSupportTest.java
+++ b/random-beans-jodatime/src/test/java/io/github/benas/randombeans/randomizers/jodatime/JodaTimeSupportTest.java
@@ -23,18 +23,19 @@
  */
 package io.github.benas.randombeans.randomizers.jodatime;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
 
 public class JodaTimeSupportTest {
 
     private EnhancedRandom enhancedRandom;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         enhancedRandom = aNewEnhancedRandom();
     }

--- a/random-beans-randomizers/pom.xml
+++ b/random-beans-randomizers/pom.xml
@@ -58,8 +58,8 @@
             <artifactId>javafaker</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -73,8 +73,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.tngtech.java</groupId>
-            <artifactId>junit-dataprovider</artifactId>
+            <groupId>com.tngtech.junit.dataprovider</groupId>
+            <artifactId>junit-jupiter-dataprovider</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/random-beans-randomizers/src/test/java/io/github/benas/randombeans/randomizers/EmailRandomizerTest.java
+++ b/random-beans-randomizers/src/test/java/io/github/benas/randombeans/randomizers/EmailRandomizerTest.java
@@ -23,13 +23,13 @@
  */
 package io.github.benas.randombeans.randomizers;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 public class EmailRandomizerTest {
 

--- a/random-beans-randomizers/src/test/java/io/github/benas/randombeans/randomizers/GenericStringRandomizerTest.java
+++ b/random-beans-randomizers/src/test/java/io/github/benas/randombeans/randomizers/GenericStringRandomizerTest.java
@@ -23,18 +23,18 @@
  */
 package io.github.benas.randombeans.randomizers;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.GenericStringRandomizer.aNewGenericStringRandomizer;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.BDDAssertions.then;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class GenericStringRandomizerTest extends AbstractRandomizerTest<String> {
 
     private String[] words;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         words = new String[]{"foo", "bar"};
     }

--- a/random-beans-randomizers/src/test/java/io/github/benas/randombeans/randomizers/RandomizersTest.java
+++ b/random-beans-randomizers/src/test/java/io/github/benas/randombeans/randomizers/RandomizersTest.java
@@ -46,16 +46,16 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 import java.text.DecimalFormatSymbols;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.UseDataProviderExtension;
 
 import io.github.benas.randombeans.api.Randomizer;
 
-@RunWith(DataProviderRunner.class)
+@ExtendWith(UseDataProviderExtension.class)
 public class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer<?>>{
 
     @DataProvider
@@ -83,7 +83,7 @@ public class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateRandomizers")
     public void generatedNumberShouldNotBeNull(Randomizer<?> randomizer) {
         // when
@@ -117,7 +117,7 @@ public class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateSeededRandomizersAndTheirExpectedValues")
     public void shouldGenerateTheSameValueForTheSameSeed(Randomizer<?> randomizer, Object expected) {
         //when
@@ -150,7 +150,7 @@ public class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateSeededRandomizersWithLocaleAndTheirExpectedValues")
     public void shouldGenerateTheSameValueForTheSameSeedForSameLocale(Randomizer<?> randomizer, Object expected) {
         //when

--- a/random-beans-spring/pom.xml
+++ b/random-beans-spring/pom.xml
@@ -58,8 +58,8 @@
             <artifactId>spring-context</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/random-beans-spring/src/test/java/io/github/benas/randombeans/spring/EnhancedRandomFactoryBeanTest.java
+++ b/random-beans-spring/src/test/java/io/github/benas/randombeans/spring/EnhancedRandomFactoryBeanTest.java
@@ -23,12 +23,13 @@
  */
 package io.github.benas.randombeans.spring;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.github.benas.randombeans.api.EnhancedRandom;
 
 public class EnhancedRandomFactoryBeanTest {
 

--- a/random-beans-validation/pom.xml
+++ b/random-beans-validation/pom.xml
@@ -68,8 +68,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/random-beans-validation/src/test/java/io/github/benas/randombeans/validation/BeanValidationTest.java
+++ b/random-beans-validation/src/test/java/io/github/benas/randombeans/validation/BeanValidationTest.java
@@ -23,26 +23,28 @@
  */
 package io.github.benas.randombeans.validation;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import org.junit.Before;
-import org.junit.Test;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.Set;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
-import java.math.BigDecimal;
-import java.util.Set;
 
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
 
 public class BeanValidationTest {
 
     private EnhancedRandom enhancedRandom;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         enhancedRandom = aNewEnhancedRandom();
     }

--- a/random-beans/pom.xml
+++ b/random-beans/pom.xml
@@ -66,8 +66,13 @@
             <artifactId>lombok</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -81,8 +86,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.tngtech.java</groupId>
-            <artifactId>junit-dataprovider</artifactId>
+            <groupId>com.tngtech.junit.dataprovider</groupId>
+            <artifactId>junit-jupiter-dataprovider</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/ArrayPopulatorTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/ArrayPopulatorTest.java
@@ -23,21 +23,22 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.api.Randomizer;
-import io.github.benas.randombeans.beans.ArrayBean;
-import io.github.benas.randombeans.beans.Person;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Array;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.lang.reflect.Array;
-
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.api.Randomizer;
+import io.github.benas.randombeans.beans.ArrayBean;
+import io.github.benas.randombeans.beans.Person;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ArrayPopulatorTest {

--- a/random-beans/src/test/java/io/github/benas/randombeans/CollectionPopulatorTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/CollectionPopulatorTest.java
@@ -23,24 +23,36 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.api.ObjectGenerationException;
-import io.github.benas.randombeans.beans.*;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.api.ObjectGenerationException;
+import io.github.benas.randombeans.beans.CollectionBean;
+import io.github.benas.randombeans.beans.CompositeCollectionBean;
+import io.github.benas.randombeans.beans.CustomList;
+import io.github.benas.randombeans.beans.DelayedQueueBean;
+import io.github.benas.randombeans.beans.Person;
+import io.github.benas.randombeans.beans.SynchronousQueueBean;
+import io.github.benas.randombeans.beans.TypeVariableCollectionBean;
+import io.github.benas.randombeans.beans.WildCardCollectionBean;
 import lombok.Data;
-
-import java.lang.reflect.Field;
-import java.util.*;
-
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
@@ -341,18 +353,18 @@ public class CollectionPopulatorTest {
         assertThat(compositeCollectionBean.getTypedQueueOdQueues()).isEmpty();
     }
 
-    @Test(expected = ObjectGenerationException.class)
+    @Test
     public void synchronousQueueTypeMustBeRejected() {
         EnhancedRandom enhancedRandom = aNewEnhancedRandom();
 
-        enhancedRandom.nextObject(SynchronousQueueBean.class);
+        assertThatThrownBy(() -> enhancedRandom.nextObject(SynchronousQueueBean.class)).isInstanceOf(ObjectGenerationException.class);
     }
 
-    @Test(expected = ObjectGenerationException.class)
+    @Test
     public void delayedQueueTypeMustBeRejected() {
         EnhancedRandom enhancedRandom = aNewEnhancedRandom();
 
-        enhancedRandom.nextObject(DelayedQueueBean.class);
+        assertThatThrownBy(() -> enhancedRandom.nextObject(DelayedQueueBean.class)).isInstanceOf(ObjectGenerationException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/EnhancedRandomBuilderTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/EnhancedRandomBuilderTest.java
@@ -23,22 +23,24 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.api.Randomizer;
-import io.github.benas.randombeans.api.RandomizerRegistry;
-import io.github.benas.randombeans.beans.Human;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+import static io.github.benas.randombeans.FieldDefinitionBuilder.field;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Supplier;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.function.Supplier;
-
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
-import static io.github.benas.randombeans.FieldDefinitionBuilder.field;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.api.Randomizer;
+import io.github.benas.randombeans.api.RandomizerRegistry;
+import io.github.benas.randombeans.beans.Human;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")
@@ -128,18 +130,18 @@ public class EnhancedRandomBuilderTest {
         assertThat(actual).isEqualTo(human);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeMinStringLength() {
         enhancedRandomBuilder = aNewEnhancedRandomBuilder();
 
-        enhancedRandomBuilder.stringLengthRange(-1, 10).build();
+        assertThatThrownBy(() -> enhancedRandomBuilder.stringLengthRange(-1, 10).build()).isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowMinStringLengthGreaterThanMaxStringLength() {
         enhancedRandomBuilder = aNewEnhancedRandomBuilder();
 
-        enhancedRandomBuilder.stringLengthRange(2, 1).build();
+        assertThatThrownBy(() -> enhancedRandomBuilder.stringLengthRange(2, 1).build()).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/EnhancedRandomImplTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/EnhancedRandomImplTest.java
@@ -23,18 +23,23 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.api.ObjectGenerationException;
-import io.github.benas.randombeans.api.Randomizer;
-import io.github.benas.randombeans.beans.*;
-import io.github.benas.randombeans.randomizers.misc.ConstantRandomizer;
-import io.github.benas.randombeans.util.ReflectionUtils;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+import static io.github.benas.randombeans.FieldDefinitionBuilder.field;
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static io.github.benas.randombeans.api.EnhancedRandom.randomCollectionOf;
+import static io.github.benas.randombeans.api.EnhancedRandom.randomListOf;
+import static io.github.benas.randombeans.api.EnhancedRandom.randomSetOf;
+import static io.github.benas.randombeans.api.EnhancedRandom.randomStreamOf;
+import static java.sql.Timestamp.valueOf;
+import static java.time.LocalDateTime.of;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Modifier;
 import java.util.Collection;
@@ -43,18 +48,28 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
-import static io.github.benas.randombeans.FieldDefinitionBuilder.field;
-import static io.github.benas.randombeans.api.EnhancedRandom.*;
-import static java.sql.Timestamp.valueOf;
-import static java.time.LocalDateTime.of;
-import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toList;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.api.ObjectGenerationException;
+import io.github.benas.randombeans.api.Randomizer;
+import io.github.benas.randombeans.beans.AbstractBean;
+import io.github.benas.randombeans.beans.Address;
+import io.github.benas.randombeans.beans.Gender;
+import io.github.benas.randombeans.beans.Human;
+import io.github.benas.randombeans.beans.ImmutableBean;
+import io.github.benas.randombeans.beans.Node;
+import io.github.benas.randombeans.beans.Person;
+import io.github.benas.randombeans.beans.Street;
+import io.github.benas.randombeans.beans.TestData;
+import io.github.benas.randombeans.beans.TestEnum;
+import io.github.benas.randombeans.randomizers.misc.ConstantRandomizer;
+import io.github.benas.randombeans.util.ReflectionUtils;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EnhancedRandomImplTest {
@@ -200,23 +215,21 @@ public class EnhancedRandomImplTest {
         assertThat(human.getName()).isEqualTo(FOO);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void ambiguousFieldDefinitionShouldBeRejected() {
-        enhancedRandom = aNewEnhancedRandomBuilder()
+        assertThatThrownBy(() -> enhancedRandom = aNewEnhancedRandomBuilder()
                 .randomize(field().named("name").get(), new ConstantRandomizer<>("name"))
-                .build();
-
-        enhancedRandom.nextObject(Person.class);
+                .build()).isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedNumberOfBeansToGenerateIsNegative_thenShouldThrowAnIllegalArgumentException() {
-        enhancedRandom.objects(Person.class, -2);
+        assertThatThrownBy(() -> enhancedRandom.objects(Person.class, -2)).isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = ObjectGenerationException.class)
+    @Test
     public void whenUnableToInstantiateField_thenShouldThrowObjectGenerationException() {
-        enhancedRandom.nextObject(AbstractBean.class);
+        assertThatThrownBy(() -> enhancedRandom.nextObject(AbstractBean.class)).isInstanceOf(ObjectGenerationException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/FieldDefinitionBuilderTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/FieldDefinitionBuilderTest.java
@@ -23,11 +23,12 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.beans.Human;
-import org.junit.Before;
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.beans.Human;
 
 public class FieldDefinitionBuilderTest {
 
@@ -37,7 +38,7 @@ public class FieldDefinitionBuilderTest {
 
     private FieldDefinitionBuilder builder;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         builder = new FieldDefinitionBuilder();
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/FieldExclusionCheckerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/FieldExclusionCheckerTest.java
@@ -23,16 +23,17 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.beans.Human;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.lang.reflect.Field;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import io.github.benas.randombeans.beans.Human;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FieldExclusionCheckerTest {

--- a/random-beans/src/test/java/io/github/benas/randombeans/FieldExclusionTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/FieldExclusionTest.java
@@ -23,17 +23,6 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.beans.Address;
-import io.github.benas.randombeans.beans.Website;
-import io.github.benas.randombeans.beans.exclusion.C;
-import io.github.benas.randombeans.beans.Human;
-import io.github.benas.randombeans.beans.Person;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
-
 import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
 import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
 import static io.github.benas.randombeans.FieldDefinitionBuilder.field;
@@ -42,6 +31,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.beans.Address;
+import io.github.benas.randombeans.beans.Human;
+import io.github.benas.randombeans.beans.Person;
+import io.github.benas.randombeans.beans.Website;
+import io.github.benas.randombeans.beans.exclusion.C;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FieldExclusionTest {

--- a/random-beans/src/test/java/io/github/benas/randombeans/FieldPopulatorTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/FieldPopulatorTest.java
@@ -23,15 +23,9 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.api.Randomizer;
-import io.github.benas.randombeans.beans.*;
-import io.github.benas.randombeans.randomizers.misc.SkipRandomizer;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.Collection;
@@ -41,9 +35,19 @@ import java.util.Map;
 
 import javax.xml.bind.JAXBElement;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.BDDAssertions.thenThrownBy;
-import static org.mockito.Mockito.when;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import io.github.benas.randombeans.api.Randomizer;
+import io.github.benas.randombeans.beans.ArrayBean;
+import io.github.benas.randombeans.beans.CollectionBean;
+import io.github.benas.randombeans.beans.Human;
+import io.github.benas.randombeans.beans.MapBean;
+import io.github.benas.randombeans.beans.Person;
+import io.github.benas.randombeans.randomizers.misc.SkipRandomizer;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")

--- a/random-beans/src/test/java/io/github/benas/randombeans/MapPopulatorTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/MapPopulatorTest.java
@@ -23,22 +23,32 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.beans.*;
-import lombok.Data;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.lang.reflect.Field;
-import java.util.*;
-
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.mockito.Mockito.when;
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.beans.CompositeMapBean;
+import io.github.benas.randombeans.beans.CustomMap;
+import io.github.benas.randombeans.beans.EnumMapBean;
+import io.github.benas.randombeans.beans.MapBean;
+import io.github.benas.randombeans.beans.Person;
+import io.github.benas.randombeans.beans.WildCardMapBean;
+import lombok.Data;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings({"unchecked", "rawtypes"})

--- a/random-beans/src/test/java/io/github/benas/randombeans/ObjectFactoryTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/ObjectFactoryTest.java
@@ -23,15 +23,16 @@
  */
 package io.github.benas.randombeans;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collection;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.DelayQueue;
 import java.util.concurrent.SynchronousQueue;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ObjectFactoryTest {
 
@@ -39,7 +40,7 @@ public class ObjectFactoryTest {
 
     private ObjectFactory objectFactory;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         objectFactory = new ObjectFactory();
     }
@@ -51,10 +52,10 @@ public class ObjectFactoryTest {
         assertThat(string).isNotNull();
     }
 
-    @Test(expected = InstantiationError.class)
+    @Test
     public void whenNoConcreteTypeIsFound_thenShouldThrowAnInstantiationError() {
         objectFactory.setScanClasspathForConcreteTypes(true);
-        objectFactory.createInstance(AbstractFoo.class);
+        assertThatThrownBy(() -> objectFactory.createInstance(AbstractFoo.class)).isInstanceOf(InstantiationError.class);
     }
 
     @Test
@@ -65,14 +66,14 @@ public class ObjectFactoryTest {
         assertThat(((ArrayBlockingQueue<?>) collection).remainingCapacity()).isEqualTo(INITIAL_CAPACITY);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void synchronousQueueShouldBeRejected() {
-        objectFactory.createEmptyCollectionForType(SynchronousQueue.class, INITIAL_CAPACITY);
+        assertThatThrownBy(() -> objectFactory.createEmptyCollectionForType(SynchronousQueue.class, INITIAL_CAPACITY)).isInstanceOf(UnsupportedOperationException.class);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void delayQueueShouldBeRejected() {
-        objectFactory.createEmptyCollectionForType(DelayQueue.class, INITIAL_CAPACITY);
+        assertThatThrownBy(() -> objectFactory.createEmptyCollectionForType(DelayQueue.class, INITIAL_CAPACITY)).isInstanceOf(UnsupportedOperationException.class);
     }
 
     private abstract class AbstractFoo {

--- a/random-beans/src/test/java/io/github/benas/randombeans/PriorityComparatorTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/PriorityComparatorTest.java
@@ -23,14 +23,15 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.annotation.Priority;
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.annotation.Priority;
 
 public class PriorityComparatorTest {
 
@@ -40,7 +41,7 @@ public class PriorityComparatorTest {
 
     private Bar bar;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         priorityComparator = new PriorityComparator();
         foo = new Foo();

--- a/random-beans/src/test/java/io/github/benas/randombeans/RandomizationContextTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/RandomizationContextTest.java
@@ -23,20 +23,21 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.api.EnhancedRandomParameters;
-import io.github.benas.randombeans.beans.Address;
-import io.github.benas.randombeans.beans.Person;
-import io.github.benas.randombeans.util.Constants;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.lang.reflect.Field;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import io.github.benas.randombeans.api.EnhancedRandomParameters;
+import io.github.benas.randombeans.beans.Address;
+import io.github.benas.randombeans.beans.Person;
+import io.github.benas.randombeans.util.Constants;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RandomizationContextTest {

--- a/random-beans/src/test/java/io/github/benas/randombeans/RandomizerAnnotationTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/RandomizerAnnotationTest.java
@@ -23,13 +23,14 @@
  */
 package io.github.benas.randombeans;
 
-import org.junit.Test;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
 
 import io.github.benas.randombeans.api.ObjectGenerationException;
 import io.github.benas.randombeans.api.Randomizer;
-
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class RandomizerAnnotationTest {
 
@@ -39,10 +40,10 @@ public class RandomizerAnnotationTest {
         assertThat(foo.getName()).isEqualTo("foo");
     }
 
-    @Test(expected=ObjectGenerationException.class)
+    @Test
     // https://github.com/benas/random-beans/issues/131
     public void shouldThrowObjectGenerationExceptionWhenRandomizerUsedInRandomizerAnnotationHasNoDefaultConstructor() {
-        aNewEnhancedRandom().nextObject(Bar.class);
+        assertThatThrownBy(() -> aNewEnhancedRandom().nextObject(Bar.class)).isInstanceOf(ObjectGenerationException.class);
     }
 
     private class Bar {

--- a/random-beans/src/test/java/io/github/benas/randombeans/RandomizerProviderTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/RandomizerProviderTest.java
@@ -23,20 +23,21 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.api.Randomizer;
-import io.github.benas.randombeans.api.RandomizerRegistry;
-import io.github.benas.randombeans.beans.Foo;
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.lang.reflect.Field;
-
-import static java.util.Collections.singleton;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import io.github.benas.randombeans.api.Randomizer;
+import io.github.benas.randombeans.api.RandomizerRegistry;
+import io.github.benas.randombeans.beans.Foo;
 
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked")

--- a/random-beans/src/test/java/io/github/benas/randombeans/RandomizerProxyTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/RandomizerProxyTest.java
@@ -23,14 +23,15 @@
  */
 package io.github.benas.randombeans;
 
-import io.github.benas.randombeans.api.Randomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.Supplier;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.function.Supplier;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import io.github.benas.randombeans.api.Randomizer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RandomizerProxyTest {

--- a/random-beans/src/test/java/io/github/benas/randombeans/parameters/CharsetParameterTests.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/parameters/CharsetParameterTests.java
@@ -23,18 +23,19 @@
  */
 package io.github.benas.randombeans.parameters;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.beans.Person;
-import org.junit.Test;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+import static io.github.benas.randombeans.util.CharacterUtils.collectPrintableCharactersOf;
+import static io.github.benas.randombeans.util.CharacterUtils.filterLetters;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
-import static io.github.benas.randombeans.util.CharacterUtils.collectPrintableCharactersOf;
-import static io.github.benas.randombeans.util.CharacterUtils.filterLetters;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.beans.Person;
 
 public class CharsetParameterTests {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/parameters/CollectionSizeRangeParameterTests.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/parameters/CollectionSizeRangeParameterTests.java
@@ -23,24 +23,26 @@
  */
 package io.github.benas.randombeans.parameters;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import org.junit.Test;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
 
 public class CollectionSizeRangeParameterTests {
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowNegativeMinCollectionSize() {
-        aNewEnhancedRandomBuilder().collectionSizeRange(-1, 10).build();
+        assertThatThrownBy(() -> aNewEnhancedRandomBuilder().collectionSizeRange(-1, 10).build()).isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void shouldNotAllowMinCollectionSizeGreaterThanMaxCollectionSize() {
-        aNewEnhancedRandomBuilder().collectionSizeRange(2, 1).build();
+        assertThatThrownBy(() -> aNewEnhancedRandomBuilder().collectionSizeRange(2, 1).build()).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/parameters/DateTimeRangeParameterTests.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/parameters/DateTimeRangeParameterTests.java
@@ -23,15 +23,16 @@
  */
 package io.github.benas.randombeans.parameters;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.beans.TimeBean;
-import org.junit.Test;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.beans.TimeBean;
 
 public class DateTimeRangeParameterTests {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/parameters/MaxObjectPoolSizeTests.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/parameters/MaxObjectPoolSizeTests.java
@@ -23,12 +23,13 @@
  */
 package io.github.benas.randombeans.parameters;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.beans.PersonTuple;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.beans.PersonTuple;
 
 public class MaxObjectPoolSizeTests {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/parameters/OverrideDefaultInitializationParameterTests.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/parameters/OverrideDefaultInitializationParameterTests.java
@@ -23,13 +23,14 @@
  */
 package io.github.benas.randombeans.parameters;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.beans.BeanWithDefaultFieldValues;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.beans.BeanWithDefaultFieldValues;
 
 public class OverrideDefaultInitializationParameterTests {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/parameters/RandomizationDepthParameterTests.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/parameters/RandomizationDepthParameterTests.java
@@ -23,12 +23,13 @@
  */
 package io.github.benas.randombeans.parameters;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.beans.Person;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.beans.Person;
 
 public class RandomizationDepthParameterTests {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/parameters/ScanClasspathForConcreteTypesParameterTests.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/parameters/ScanClasspathForConcreteTypesParameterTests.java
@@ -23,27 +23,38 @@
  */
 package io.github.benas.randombeans.parameters;
 
-import io.github.benas.randombeans.EnhancedRandomBuilder;
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.api.ObjectGenerationException;
-import io.github.benas.randombeans.beans.*;
-import org.junit.Test;
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.BDDAssertions.then;
 
 import java.util.Date;
 
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.BDDAssertions.then;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.EnhancedRandomBuilder;
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.api.ObjectGenerationException;
+import io.github.benas.randombeans.beans.Ape;
+import io.github.benas.randombeans.beans.Bar;
+import io.github.benas.randombeans.beans.ClassUsingAbstractEnum;
+import io.github.benas.randombeans.beans.ComparableBean;
+import io.github.benas.randombeans.beans.ConcreteBar;
+import io.github.benas.randombeans.beans.Foo;
+import io.github.benas.randombeans.beans.Human;
+import io.github.benas.randombeans.beans.Mamals;
+import io.github.benas.randombeans.beans.Person;
+import io.github.benas.randombeans.beans.SocialPerson;
 
 public class ScanClasspathForConcreteTypesParameterTests {
 
     private EnhancedRandom enhancedRandom;
 
-    @Test(expected = ObjectGenerationException.class)
+    @Test
     public void whenScanClasspathForConcreteTypesIsDisabled_thenShouldFailToPopulateInterfacesAndAbstractClasses() {
         enhancedRandom = aNewEnhancedRandomBuilder().scanClasspathForConcreteTypes(false).build();
 
-        enhancedRandom.nextObject(Mamals.class);
+        assertThatThrownBy(() -> enhancedRandom.nextObject(Mamals.class)).isInstanceOf(ObjectGenerationException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/parameters/SeedParameterTests.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/parameters/SeedParameterTests.java
@@ -23,15 +23,16 @@
  */
 package io.github.benas.randombeans.parameters;
 
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
 import io.github.benas.randombeans.api.EnhancedRandom;
 import io.github.benas.randombeans.beans.Address;
 import io.github.benas.randombeans.beans.Gender;
 import io.github.benas.randombeans.beans.Person;
 import io.github.benas.randombeans.beans.Street;
-import org.junit.Test;
-
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class SeedParameterTests {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/parameters/StringLengthRangeParameterTests.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/parameters/StringLengthRangeParameterTests.java
@@ -23,12 +23,13 @@
  */
 package io.github.benas.randombeans.parameters;
 
-import io.github.benas.randombeans.api.EnhancedRandom;
-import io.github.benas.randombeans.beans.Person;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandomBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.beans.Person;
 
 public class StringLengthRangeParameterTests {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/collection/CollectionRandomizersTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/collection/CollectionRandomizersTest.java
@@ -35,16 +35,16 @@ import static org.mockito.Mockito.when;
 import java.util.Collection;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.UseDataProviderExtension;
 
 import io.github.benas.randombeans.api.Randomizer;
 
-@RunWith(DataProviderRunner.class)
+@ExtendWith(UseDataProviderExtension.class)
 public class CollectionRandomizersTest {
 
     private static final int collectionSize = 3;
@@ -58,7 +58,7 @@ public class CollectionRandomizersTest {
                 aNewSetRandomizer(elementRandomizer) };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateCollectionRandomizers")
     public <T> void generatedCollectionShouldNotBeNull(Randomizer<Collection<T>> collectionRandomizer) {
         // when
@@ -75,7 +75,7 @@ public class CollectionRandomizersTest {
                 aNewSetRandomizer(elementRandomizer(), collectionSize) };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateCollectionRandomizersWithSpecificSize")
     public <T> void generatedCollectionSizeShouldBeEqualToTheSpecifiedSize(Randomizer<Collection<T>> collectionRandomizer) {
         // when
@@ -92,7 +92,7 @@ public class CollectionRandomizersTest {
                 aNewSetRandomizer(elementRandomizer(), 0) };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateCollectionRandomizersForEmptyCollections")
     public <T> void shouldAllowGeneratingEmptyCollections(Randomizer<Collection<T>> collectionRandomizer) {
         // when
@@ -111,7 +111,7 @@ public class CollectionRandomizersTest {
                 (ThrowingCallable) () -> aNewSetRandomizer(elementRandomizer, illegalSize) };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateCollectionRandomizersWithIllegalSize")
     public void specifiedSizeShouldBePositive(ThrowingCallable callable) {
         // when

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/collection/MapRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/collection/MapRandomizerTest.java
@@ -23,16 +23,18 @@
  */
 package io.github.benas.randombeans.randomizers.collection;
 
-import io.github.benas.randombeans.api.Randomizer;
+import static io.github.benas.randombeans.randomizers.collection.MapRandomizer.aNewMapRandomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static io.github.benas.randombeans.randomizers.collection.MapRandomizer.aNewMapRandomizer;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import io.github.benas.randombeans.api.Randomizer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MapRandomizerTest {
@@ -63,18 +65,18 @@ public class MapRandomizerTest {
         assertThat(aNewMapRandomizer(keyRandomizer, valueRandomizer, 0).getRandomValue()).isEmpty();
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void specifiedSizeShouldBePositive() {
-        aNewMapRandomizer(keyRandomizer, valueRandomizer, -3);
+        assertThatThrownBy(() -> aNewMapRandomizer(keyRandomizer, valueRandomizer, -3)).isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void nullKeyRandomizer() {
-        aNewMapRandomizer(null, valueRandomizer, 3);
+        assertThatThrownBy(() -> aNewMapRandomizer(null, valueRandomizer, 3)).isInstanceOf(NullPointerException.class);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void nullValueRandomizer() {
-        aNewMapRandomizer(keyRandomizer, null, 3);
+        assertThatThrownBy(() -> aNewMapRandomizer(keyRandomizer, null, 3)).isInstanceOf(NullPointerException.class);
     }
 }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/BooleanRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/BooleanRandomizerTest.java
@@ -23,11 +23,12 @@
  */
 package io.github.benas.randombeans.randomizers.misc;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.misc.BooleanRandomizer.aNewBooleanRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 
 public class BooleanRandomizerTest extends AbstractRandomizerTest<Boolean> {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/ConstantRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/ConstantRandomizerTest.java
@@ -23,10 +23,10 @@
  */
 package io.github.benas.randombeans.randomizers.misc;
 
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.misc.ConstantRandomizer.aNewConstantRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 public class ConstantRandomizerTest {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/EnumRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/EnumRandomizerTest.java
@@ -26,9 +26,11 @@ package io.github.benas.randombeans.randomizers.misc;
 import static io.github.benas.randombeans.randomizers.misc.EnumRandomizer.aNewEnumRandomizer;
 import static io.github.benas.randombeans.randomizers.misc.EnumRandomizerTest.Gender.FEMALE;
 import static org.assertj.core.api.Assertions.assertThat;
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 
 public class EnumRandomizerTest extends AbstractRandomizerTest<EnumRandomizerTest.Gender> {
 
@@ -54,8 +56,8 @@ public class EnumRandomizerTest extends AbstractRandomizerTest<EnumRandomizerTes
         assertThat(randomElement).isNotEqualTo(valueToExclude);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void should_throw_an_exception_when_all_values_are_excluded() {
-        aNewEnumRandomizer(Gender.class, Gender.values());
+        assertThatThrownBy(() -> aNewEnumRandomizer(Gender.class, Gender.values())).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/LocaleRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/LocaleRandomizerTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/NullRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/NullRandomizerTest.java
@@ -23,10 +23,10 @@
  */
 package io.github.benas.randombeans.randomizers.misc;
 
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.misc.NullRandomizer.aNewNullRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 public class NullRandomizerTest {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/OptionalRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/OptionalRandomizerTest.java
@@ -23,15 +23,16 @@
  */
 package io.github.benas.randombeans.randomizers.misc;
 
-import io.github.benas.randombeans.api.Randomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import io.github.benas.randombeans.api.Randomizer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class OptionalRandomizerTest {

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/SkipRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/SkipRandomizerTest.java
@@ -23,10 +23,10 @@
  */
 package io.github.benas.randombeans.randomizers.misc;
 
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.misc.SkipRandomizer.aNewSkipRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 public class SkipRandomizerTest {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/UUIDRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/misc/UUIDRandomizerTest.java
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Locale;
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/net/NetRandomizersTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/net/NetRandomizersTest.java
@@ -23,24 +23,27 @@
  */
 package io.github.benas.randombeans.randomizers.net;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import io.github.benas.randombeans.api.Randomizer;
-import io.github.benas.randombeans.beans.Website;
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import java.net.URI;
-import java.net.URL;
-
 import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
 import static io.github.benas.randombeans.randomizers.net.UriRandomizer.aNewUriRandomizer;
 import static io.github.benas.randombeans.randomizers.net.UrlRandomizer.aNewUrlRandomizer;
 import static org.assertj.core.api.BDDAssertions.then;
 
-@RunWith(DataProviderRunner.class)
+import java.net.URI;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.UseDataProviderExtension;
+
+import io.github.benas.randombeans.api.Randomizer;
+import io.github.benas.randombeans.beans.Website;
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
+
+@ExtendWith(UseDataProviderExtension.class)
 public class NetRandomizersTest extends AbstractRandomizerTest<Randomizer<?>> {
 
     @DataProvider
@@ -51,7 +54,7 @@ public class NetRandomizersTest extends AbstractRandomizerTest<Randomizer<?>> {
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateRandomizers")
     public void generatedValueShouldNotBeNull(Randomizer<?> randomizer) {
         // when
@@ -68,7 +71,7 @@ public class NetRandomizersTest extends AbstractRandomizerTest<Randomizer<?>> {
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateSeededRandomizersAndTheirExpectedValues")
     public void shouldGenerateTheSameValueForTheSameSeed(Randomizer<?> randomizer, Object expected) {
         //when

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/number/AtomicIntegerRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/number/AtomicIntegerRandomizerTest.java
@@ -23,13 +23,14 @@
  */
 package io.github.benas.randombeans.randomizers.number;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import org.junit.Test;
+import static io.github.benas.randombeans.randomizers.number.AtomicIntegerRandomizer.aNewAtomicIntegerRandomizer;
+import static org.assertj.core.api.BDDAssertions.then;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static io.github.benas.randombeans.randomizers.number.AtomicIntegerRandomizer.aNewAtomicIntegerRandomizer;
-import static org.assertj.core.api.BDDAssertions.then;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 
 public class AtomicIntegerRandomizerTest extends AbstractRandomizerTest<AtomicInteger> {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/number/AtomicLongRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/number/AtomicLongRandomizerTest.java
@@ -23,13 +23,14 @@
  */
 package io.github.benas.randombeans.randomizers.number;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import org.junit.Test;
+import static io.github.benas.randombeans.randomizers.number.AtomicLongRandomizer.aNewAtomicLongRandomizer;
+import static org.assertj.core.api.BDDAssertions.then;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import static io.github.benas.randombeans.randomizers.number.AtomicLongRandomizer.aNewAtomicLongRandomizer;
-import static org.assertj.core.api.BDDAssertions.then;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 
 public class AtomicLongRandomizerTest extends AbstractRandomizerTest<AtomicLong> {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/number/BigDecimalRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/number/BigDecimalRandomizerTest.java
@@ -23,13 +23,14 @@
  */
 package io.github.benas.randombeans.randomizers.number;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import org.junit.Test;
+import static io.github.benas.randombeans.randomizers.number.BigDecimalRandomizer.aNewBigDecimalRandomizer;
+import static org.assertj.core.api.BDDAssertions.then;
 
 import java.math.BigDecimal;
 
-import static io.github.benas.randombeans.randomizers.number.BigDecimalRandomizer.aNewBigDecimalRandomizer;
-import static org.assertj.core.api.BDDAssertions.then;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 
 public class BigDecimalRandomizerTest extends AbstractRandomizerTest<BigDecimal> {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/number/NumberRandomizersTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/number/NumberRandomizersTest.java
@@ -23,18 +23,6 @@
  */
 package io.github.benas.randombeans.randomizers.number;
 
-import io.github.benas.randombeans.api.Randomizer;
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
-
-import java.math.BigDecimal;
-import java.math.BigInteger;
-
 import static io.github.benas.randombeans.randomizers.number.BigDecimalRandomizer.aNewBigDecimalRandomizer;
 import static io.github.benas.randombeans.randomizers.number.BigIntegerRandomizer.aNewBigIntegerRandomizer;
 import static io.github.benas.randombeans.randomizers.number.ByteRandomizer.aNewByteRandomizer;
@@ -45,7 +33,20 @@ import static io.github.benas.randombeans.randomizers.number.LongRandomizer.aNew
 import static io.github.benas.randombeans.randomizers.number.ShortRandomizer.aNewShortRandomizer;
 import static org.assertj.core.api.BDDAssertions.then;
 
-@RunWith(DataProviderRunner.class)
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.UseDataProviderExtension;
+
+import io.github.benas.randombeans.api.Randomizer;
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
+
+@ExtendWith(UseDataProviderExtension.class)
 public class NumberRandomizersTest extends AbstractRandomizerTest<Object> {
 
     @DataProvider
@@ -62,7 +63,7 @@ public class NumberRandomizersTest extends AbstractRandomizerTest<Object> {
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateRandomizers")
     public void generatedNumberShouldNotBeNull(Randomizer<?> randomizer) {
         // when
@@ -85,7 +86,7 @@ public class NumberRandomizersTest extends AbstractRandomizerTest<Object> {
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateSeededRandomizersAndTheirExpectedValues")
     public void shouldGenerateTheSameValueForTheSameSeed(Randomizer<?> randomizer, Object expected) {
         //when

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/BigDecimalRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/BigDecimalRangeRandomizerTest.java
@@ -23,20 +23,21 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
+import static io.github.benas.randombeans.randomizers.range.BigDecimalRangeRandomizer.aNewBigDecimalRangeRandomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.BDDAssertions.then;
 
 import java.math.BigDecimal;
 
-import static io.github.benas.randombeans.randomizers.range.BigDecimalRangeRandomizer.aNewBigDecimalRangeRandomizer;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.BDDAssertions.then;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BigDecimalRangeRandomizerTest extends AbstractRangeRandomizerTest<BigDecimal> {
 
     private Long min, max;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         min = 1L;
         max = 10L;
@@ -49,9 +50,9 @@ public class BigDecimalRangeRandomizerTest extends AbstractRangeRandomizerTest<B
         assertThat(randomValue.longValue()).isBetween(min, max);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinValueIsAfterMaxValueThenThrowIllegalArgumentException() {
-        aNewBigDecimalRangeRandomizer(max, min);
+        assertThatThrownBy(() -> aNewBigDecimalRangeRandomizer(max, min)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/BigIntegerRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/BigIntegerRangeRandomizerTest.java
@@ -23,20 +23,21 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
+import static io.github.benas.randombeans.randomizers.range.BigIntegerRangeRandomizer.aNewBigIntegerRangeRandomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.BDDAssertions.then;
 
 import java.math.BigInteger;
 
-import static io.github.benas.randombeans.randomizers.range.BigIntegerRangeRandomizer.aNewBigIntegerRangeRandomizer;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.BDDAssertions.then;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BigIntegerRangeRandomizerTest extends AbstractRangeRandomizerTest<BigInteger> {
 
     private Integer min, max;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         min = 1;
         max = 10;
@@ -49,9 +50,9 @@ public class BigIntegerRangeRandomizerTest extends AbstractRangeRandomizerTest<B
         assertThat(randomValue.intValue()).isBetween(min, max);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinValueIsAfterMaxValueThenThrowIllegalArgumentException() {
-        aNewBigIntegerRangeRandomizer(max, min);
+        assertThatThrownBy(() -> aNewBigIntegerRangeRandomizer(max, min)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/ByteRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/ByteRangeRandomizerTest.java
@@ -23,16 +23,17 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.range.ByteRangeRandomizer.aNewByteRangeRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ByteRangeRandomizerTest extends AbstractRangeRandomizerTest<Byte> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         min = (byte) 1;
         max = (byte) 10;
@@ -45,9 +46,9 @@ public class ByteRangeRandomizerTest extends AbstractRangeRandomizerTest<Byte> {
         assertThat(randomValue).isBetween(min, max);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinValueIsAfterMaxValueThenThrowIllegalArgumentException() {
-        aNewByteRangeRandomizer(max, min);
+        assertThatThrownBy(() -> aNewByteRangeRandomizer(max, min)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/DateRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/DateRangeRandomizerTest.java
@@ -23,19 +23,20 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
+import static io.github.benas.randombeans.randomizers.range.DateRangeRandomizer.aNewDateRangeRandomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Date;
 
-import static io.github.benas.randombeans.randomizers.range.DateRangeRandomizer.aNewDateRangeRandomizer;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DateRangeRandomizerTest extends AbstractRangeRandomizerTest<Date> {
 
     private Date minDate, maxDate;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         minDate = new Date(1460448795091L);
         maxDate = new Date(1460448795179L);
@@ -65,9 +66,9 @@ public class DateRangeRandomizerTest extends AbstractRangeRandomizerTest<Date> {
         assertThat(randomDate).isEqualTo(expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinDateIsAfterMaxDate_thenShouldThrowIllegalArgumentException() {
-        aNewDateRangeRandomizer(maxDate, minDate);
+        assertThatThrownBy(() -> aNewDateRangeRandomizer(maxDate, minDate)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/DoubleRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/DoubleRangeRandomizerTest.java
@@ -23,16 +23,17 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.range.DoubleRangeRandomizer.aNewDoubleRangeRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DoubleRangeRandomizerTest extends AbstractRangeRandomizerTest<Double> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         min = 1d;
         max = 10d;
@@ -45,9 +46,9 @@ public class DoubleRangeRandomizerTest extends AbstractRangeRandomizerTest<Doubl
         assertThat(randomValue).isBetween(min, max);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinValueIsAfterMaxValueThenThrowIllegalArgumentException() {
-        aNewDoubleRangeRandomizer(max, min);
+        assertThatThrownBy(() -> aNewDoubleRangeRandomizer(max, min)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/FloatRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/FloatRangeRandomizerTest.java
@@ -23,16 +23,17 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.range.FloatRangeRandomizer.aNewFloatRangeRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class FloatRangeRandomizerTest extends AbstractRangeRandomizerTest<Float> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         min = 1f;
         max = 10f;
@@ -45,9 +46,9 @@ public class FloatRangeRandomizerTest extends AbstractRangeRandomizerTest<Float>
         assertThat(randomValue).isBetween(min, max);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinValueIsAfterMaxValueThenThrowIllegalArgumentException() {
-        aNewFloatRangeRandomizer(max, min);
+        assertThatThrownBy(() -> aNewFloatRangeRandomizer(max, min)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/IntegerRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/IntegerRangeRandomizerTest.java
@@ -23,19 +23,21 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
+import static io.github.benas.randombeans.randomizers.range.IntegerRangeRandomizer.aNewIntegerRangeRandomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import io.github.benas.randombeans.EnhancedRandomBuilder;
 import io.github.benas.randombeans.api.EnhancedRandom;
 import io.github.benas.randombeans.beans.Street;
-import org.junit.Before;
-import org.junit.Test;
-
-import static io.github.benas.randombeans.randomizers.range.IntegerRangeRandomizer.aNewIntegerRangeRandomizer;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.BDDAssertions.then;
 
 public class IntegerRangeRandomizerTest extends AbstractRangeRandomizerTest<Integer> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         min = 1;
         max = 10;
@@ -48,9 +50,9 @@ public class IntegerRangeRandomizerTest extends AbstractRangeRandomizerTest<Inte
         assertThat(randomValue).isBetween(min, max);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinValueIsAfterMaxValueThenThrowIllegalArgumentException() {
-        aNewIntegerRangeRandomizer(max, min);
+        assertThatThrownBy(() -> aNewIntegerRangeRandomizer(max, min)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/LocalDateRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/LocalDateRangeRandomizerTest.java
@@ -23,19 +23,20 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
+import static io.github.benas.randombeans.randomizers.range.LocalDateRangeRandomizer.aNewLocalDateRangeRandomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
 
-import static io.github.benas.randombeans.randomizers.range.LocalDateRangeRandomizer.aNewLocalDateRangeRandomizer;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LocalDateRangeRandomizerTest extends AbstractRangeRandomizerTest<LocalDate> {
 
     private LocalDate minDate, maxDate;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         minDate = LocalDate.MIN;
         maxDate = LocalDate.MAX;
@@ -65,9 +66,9 @@ public class LocalDateRangeRandomizerTest extends AbstractRangeRandomizerTest<Lo
         assertThat(randomValue).isEqualTo(expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinDateIsAfterMaxDate_thenShouldThrowIllegalArgumentException() {
-        aNewLocalDateRangeRandomizer(maxDate, minDate);
+        assertThatThrownBy(() -> aNewLocalDateRangeRandomizer(maxDate, minDate)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/LocalDateTimeRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/LocalDateTimeRangeRandomizerTest.java
@@ -23,21 +23,22 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
+import static io.github.benas.randombeans.randomizers.range.LocalDateTimeRangeRandomizer.aNewLocalDateTimeRangeRandomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-import static io.github.benas.randombeans.randomizers.range.LocalDateTimeRangeRandomizer.aNewLocalDateTimeRangeRandomizer;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LocalDateTimeRangeRandomizerTest extends AbstractRangeRandomizerTest<LocalDateTime> {
 
     private LocalDateTime minDateTime, maxDateTime;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         minDateTime = LocalDateTime.MIN;
         maxDateTime = LocalDateTime.MAX;
@@ -67,9 +68,9 @@ public class LocalDateTimeRangeRandomizerTest extends AbstractRangeRandomizerTes
         assertThat(randomValue).isEqualTo(expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinDateTimeIsAfterMaxDateTime_thenShouldThrowIllegalArgumentException() {
-        aNewLocalDateTimeRangeRandomizer(maxDateTime, minDateTime);
+        assertThatThrownBy(() -> aNewLocalDateTimeRangeRandomizer(maxDateTime, minDateTime)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/LocalTimeRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/LocalTimeRangeRandomizerTest.java
@@ -23,19 +23,20 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
+import static io.github.benas.randombeans.randomizers.range.LocalTimeRangeRandomizer.aNewLocalTimeRangeRandomizer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalTime;
 
-import static io.github.benas.randombeans.randomizers.range.LocalTimeRangeRandomizer.aNewLocalTimeRangeRandomizer;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LocalTimeRangeRandomizerTest extends AbstractRangeRandomizerTest<LocalTime> {
 
     private LocalTime minTime, maxTime;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         minTime = LocalTime.MIN;
         maxTime = LocalTime.MAX;
@@ -65,9 +66,9 @@ public class LocalTimeRangeRandomizerTest extends AbstractRangeRandomizerTest<Lo
         assertThat(randomValue).isEqualTo(expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinTimeIsAfterMaxDate_thenShouldThrowIllegalArgumentException() {
-        aNewLocalTimeRangeRandomizer(maxTime, minTime);
+        assertThatThrownBy(() -> aNewLocalTimeRangeRandomizer(maxTime, minTime)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/LongRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/LongRangeRandomizerTest.java
@@ -23,16 +23,17 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.range.LongRangeRandomizer.aNewLongRangeRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class LongRangeRandomizerTest extends AbstractRangeRandomizerTest<Long> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         min = 1L;
         max = 10L;
@@ -45,9 +46,9 @@ public class LongRangeRandomizerTest extends AbstractRangeRandomizerTest<Long> {
         assertThat(randomValue).isBetween(min, max);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinValueIsAfterMaxValueThenThrowIllegalArgumentException() {
-        aNewLongRangeRandomizer(max, min);
+        assertThatThrownBy(() -> aNewLongRangeRandomizer(max, min)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/ShortRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/ShortRangeRandomizerTest.java
@@ -23,16 +23,17 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.range.ShortRangeRandomizer.aNewShortRangeRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.BDDAssertions.then;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ShortRangeRandomizerTest extends AbstractRangeRandomizerTest<Short> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         min = (short) 1;
         max = (short) 10;
@@ -45,9 +46,9 @@ public class ShortRangeRandomizerTest extends AbstractRangeRandomizerTest<Short>
         assertThat(randomValue).isBetween(min, max);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinValueIsAfterMaxValueThenThrowIllegalArgumentException() {
-        aNewShortRangeRandomizer(max, min);
+        assertThatThrownBy(() -> aNewShortRangeRandomizer(max, min)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/SqlDateRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/SqlDateRangeRandomizerTest.java
@@ -23,20 +23,21 @@
  */
 package io.github.benas.randombeans.randomizers.range;
 
-import org.junit.Before;
-import org.junit.Test;
-
-import java.sql.Date;
-
 import static io.github.benas.randombeans.randomizers.range.DateRangeRandomizer.aNewDateRangeRandomizer;
 import static io.github.benas.randombeans.randomizers.range.SqlDateRangeRandomizer.aNewSqlDateRangeRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class SqlDateRangeRandomizerTest extends AbstractRangeRandomizerTest<Date> {
 
     private Date minDate, maxDate;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         minDate = new Date(1460448795091L);
         maxDate = new Date(1460448795179L);
@@ -66,9 +67,9 @@ public class SqlDateRangeRandomizerTest extends AbstractRangeRandomizerTest<Date
         assertThat(randomDate).isEqualTo(expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinDateIsAfterMaxDate_thenShouldThrowIllegalArgumentException() {
-        aNewDateRangeRandomizer(maxDate, minDate);
+        assertThatThrownBy(() -> aNewDateRangeRandomizer(maxDate, minDate)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/ZonedDateTimeRangeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/range/ZonedDateTimeRangeRandomizerTest.java
@@ -25,11 +25,12 @@ package io.github.benas.randombeans.randomizers.range;
 
 import static io.github.benas.randombeans.randomizers.range.ZonedDateTimeRangeRandomizer.aNewZonedDateTimeRangeRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.ZonedDateTime;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.github.benas.randombeans.util.Constants;
 
@@ -37,7 +38,7 @@ public class ZonedDateTimeRangeRandomizerTest extends AbstractRangeRandomizerTes
 
     private ZonedDateTime minZonedDateTime, maxZonedDateTime;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         minZonedDateTime = Constants.DEFAULT_DATES_RANGE.getMin().minusYears(50);
         maxZonedDateTime = Constants.DEFAULT_DATES_RANGE.getMax().plusYears(50);
@@ -67,9 +68,9 @@ public class ZonedDateTimeRangeRandomizerTest extends AbstractRangeRandomizerTes
         assertThat(randomValue).isEqualTo(expected);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenSpecifiedMinZonedDateTimeIsAfterMaxZonedDateTime_thenShouldThrowIllegalArgumentException() {
-        aNewZonedDateTimeRangeRandomizer(maxZonedDateTime, minZonedDateTime);
+        assertThatThrownBy(() -> aNewZonedDateTimeRangeRandomizer(maxZonedDateTime, minZonedDateTime)).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/text/CharacterRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/text/CharacterRandomizerTest.java
@@ -23,16 +23,17 @@
  */
 package io.github.benas.randombeans.randomizers.text;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.text.CharacterRandomizer.aNewCharacterRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
+
 public class CharacterRandomizerTest extends AbstractRandomizerTest<Character> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         randomizer = aNewCharacterRandomizer();
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/text/StringDelegatingRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/text/StringDelegatingRandomizerTest.java
@@ -23,17 +23,18 @@
  */
 package io.github.benas.randombeans.randomizers.text;
 
-import io.github.benas.randombeans.api.Randomizer;
+import static io.github.benas.randombeans.randomizers.text.StringDelegatingRandomizer.aNewStringDelegatingRandomizer;
+import static java.lang.String.valueOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static io.github.benas.randombeans.randomizers.text.StringDelegatingRandomizer.aNewStringDelegatingRandomizer;
-import static java.lang.String.valueOf;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import io.github.benas.randombeans.api.Randomizer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StringDelegatingRandomizerTest {

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/text/StringRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/text/StringRandomizerTest.java
@@ -23,15 +23,17 @@
  */
 package io.github.benas.randombeans.randomizers.text;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 import static io.github.benas.randombeans.randomizers.text.StringRandomizer.aNewStringRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 
 public class StringRandomizerTest extends AbstractRandomizerTest<String> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         randomizer = aNewStringRandomizer();
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/TimeRandomizersTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/TimeRandomizersTest.java
@@ -47,23 +47,35 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.time.*;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.DataProvider;
+import com.tngtech.junit.dataprovider.UseDataProvider;
+import com.tngtech.junit.dataprovider.UseDataProviderExtension;
 
 import io.github.benas.randombeans.api.Randomizer;
 import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 
-@RunWith(DataProviderRunner.class)
+@ExtendWith(UseDataProviderExtension.class)
 public class TimeRandomizersTest extends AbstractRandomizerTest<Randomizer<?>> {
 
     @DataProvider
@@ -90,7 +102,7 @@ public class TimeRandomizersTest extends AbstractRandomizerTest<Randomizer<?>> {
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateRandomizers")
     public void generatedTimeShouldNotBeNull(Randomizer<?> randomizer) {
         // when
@@ -129,7 +141,7 @@ public class TimeRandomizersTest extends AbstractRandomizerTest<Randomizer<?>> {
         };
     }
 
-    @Test
+    @TestTemplate
     @UseDataProvider("generateSeededRandomizersAndTheirExpectedValues")
     public void shouldGenerateTheSameValueForTheSameSeed(Randomizer<?> randomizer, Object expected) {
         //when

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/TimeSupportTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/TimeSupportTest.java
@@ -23,24 +23,24 @@
  */
 package io.github.benas.randombeans.randomizers.time;
 
+import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import io.github.benas.randombeans.EnhancedRandomBuilder;
 import io.github.benas.randombeans.FieldDefinitionBuilder;
 import io.github.benas.randombeans.api.EnhancedRandom;
 import io.github.benas.randombeans.beans.TimeBean;
 
-import java.time.Instant;
-
-import org.junit.Before;
-import org.junit.Test;
-
-import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRandom;
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class TimeSupportTest {
 
     private EnhancedRandom enhancedRandom;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         enhancedRandom = aNewEnhancedRandom();
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/TimeZoneRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/TimeZoneRandomizerTest.java
@@ -28,14 +28,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.TimeZone;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 
 public class TimeZoneRandomizerTest extends AbstractRandomizerTest<TimeZone> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         randomizer = aNewTimeZoneRandomizer(SEED);
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/ZoneIdRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/ZoneIdRandomizerTest.java
@@ -23,18 +23,19 @@
  */
 package io.github.benas.randombeans.randomizers.time;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.time.ZoneId;
-
 import static io.github.benas.randombeans.randomizers.time.ZoneIdRandomizer.aNewZoneIdRandomizer;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
+
 public class ZoneIdRandomizerTest extends AbstractRandomizerTest<ZoneId> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         randomizer = aNewZoneIdRandomizer(SEED);
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/ZonedDateTimeRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/ZonedDateTimeRandomizerTest.java
@@ -23,13 +23,14 @@
  */
 package io.github.benas.randombeans.randomizers.time;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import org.junit.Test;
+import static io.github.benas.randombeans.randomizers.time.ZonedDateTimeRandomizer.aNewZonedDateTimeRandomizer;
+import static org.assertj.core.api.BDDAssertions.then;
 
 import java.time.ZonedDateTime;
 
-import static io.github.benas.randombeans.randomizers.time.ZonedDateTimeRandomizer.aNewZonedDateTimeRandomizer;
-import static org.assertj.core.api.BDDAssertions.then;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
 
 public class ZonedDateTimeRandomizerTest extends AbstractRandomizerTest<ZonedDateTime> {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/internal/DayRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/internal/DayRandomizerTest.java
@@ -23,18 +23,19 @@
  */
 package io.github.benas.randombeans.randomizers.time.internal;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import io.github.benas.randombeans.randomizers.time.DayRandomizer;
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.time.DayRandomizer.MAX_DAY;
 import static io.github.benas.randombeans.randomizers.time.DayRandomizer.MIN_DAY;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
+import io.github.benas.randombeans.randomizers.time.DayRandomizer;
+
 public class DayRandomizerTest extends AbstractRandomizerTest<Integer> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         randomizer = new DayRandomizer();
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/internal/HourRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/internal/HourRandomizerTest.java
@@ -23,18 +23,19 @@
  */
 package io.github.benas.randombeans.randomizers.time.internal;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import io.github.benas.randombeans.randomizers.time.HourRandomizer;
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.time.HourRandomizer.MAX_HOUR;
 import static io.github.benas.randombeans.randomizers.time.HourRandomizer.MIN_HOUR;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
+import io.github.benas.randombeans.randomizers.time.HourRandomizer;
+
 public class HourRandomizerTest extends AbstractRandomizerTest<Integer> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         randomizer = new HourRandomizer();
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/internal/MinuteRandomizerTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/randomizers/time/internal/MinuteRandomizerTest.java
@@ -23,18 +23,19 @@
  */
 package io.github.benas.randombeans.randomizers.time.internal;
 
-import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
-import io.github.benas.randombeans.randomizers.time.MinuteRandomizer;
-import org.junit.Before;
-import org.junit.Test;
-
 import static io.github.benas.randombeans.randomizers.time.MinuteRandomizer.MAX_MINUTE;
 import static io.github.benas.randombeans.randomizers.time.MinuteRandomizer.MIN_MINUTE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.github.benas.randombeans.randomizers.AbstractRandomizerTest;
+import io.github.benas.randombeans.randomizers.time.MinuteRandomizer;
+
 public class MinuteRandomizerTest extends AbstractRandomizerTest<Integer> {
 
-    @Before
+    @BeforeEach
     public void setUp() {
         randomizer = new MinuteRandomizer();
     }

--- a/random-beans/src/test/java/io/github/benas/randombeans/util/CharacterUtilsTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/util/CharacterUtilsTest.java
@@ -23,13 +23,13 @@
  */
 package io.github.benas.randombeans.util;
 
-import org.junit.Test;
-
-import java.util.List;
-
 import static io.github.benas.randombeans.util.CharacterUtils.filterLetters;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 
 public class CharacterUtilsTest {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/util/CollectionUtilsTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/util/CollectionUtilsTest.java
@@ -23,10 +23,10 @@
  */
 package io.github.benas.randombeans.util;
 
-import org.junit.Test;
-
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 public class CollectionUtilsTest {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/util/RangeTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/util/RangeTest.java
@@ -23,9 +23,9 @@
  */
 package io.github.benas.randombeans.util;
 
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 public class RangeTest {
 

--- a/random-beans/src/test/java/io/github/benas/randombeans/util/ReflectionUtilsTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/util/ReflectionUtilsTest.java
@@ -24,7 +24,7 @@
 package io.github.benas.randombeans.util;
 
 import io.github.benas.randombeans.beans.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;

--- a/random-beans/src/test/java/io/github/benas/randombeans/visibility/VisibilityTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/visibility/VisibilityTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.function.Supplier;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.github.benas.randombeans.api.EnhancedRandom;
 


### PR DESCRIPTION
The test using mockito are still junit 4 because there is no junit 5 mockito extension yet (see: https://github.com/mockito/mockito/issues/445, https://github.com/mockito/mockito/pull/1221)