### PR TITLE
Provide BOM artefact with correct parent poms

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Coverage Status](https://coveralls.io/repos/benas/random-beans/badge.svg?branch=master&service=github)](https://coveralls.io/github/benas/random-beans?branch=master)
 [![Build Status](https://travis-ci.org/benas/random-beans.svg?branch=master)](https://travis-ci.org/benas/random-beans)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.github.benas/random-beans/badge.svg?style=flat)](http://repo1.maven.org/maven2/io/github/benas/random-beans/3.7.0/)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/io.github.benas/random-beans/badge.svg)](http://www.javadoc.io/doc/io.github.benas/random-beans)
+[![Javadocs](http://www.javadoc.io/badge/io.github.benas/random-beans.svg)](http://www.javadoc.io/doc/io.github.benas/random-beans)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/benas/random-beans)
 
 </div>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>2.20.1</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-cobertura-plugin.version>2.7</maven-cobertura-plugin.version>
         <maven-coveralls-plugin.version>4.3.0</maven-coveralls-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <groupId>io.github.benas</groupId>
-    <artifactId>random-beans-parent</artifactId>
+    <artifactId>random-beans-project</artifactId>
     <version>3.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
@@ -20,20 +20,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <lombok.version>1.16.18</lombok.version>
-        <junit.version>4.12</junit.version>
-        <faker.version>0.14</faker.version>
-        <assertj.version>3.8.0</assertj.version>
-        <validation-api.version>1.1.0.Final</validation-api.version>
-        <joda-time.version>2.9.9</joda-time.version>
-        <spring-context.version>4.3.10.RELEASE</spring-context.version>
-        <objenesis.version>2.6</objenesis.version>
-        <fast-classpath-scanner.version>2.7.5</fast-classpath-scanner.version>
-        <hibernate-validator.version>5.4.1.Final</hibernate-validator.version>
-        <javax.el.version>2.2.6</javax.el.version>
-        <jackson.version>2.9.2</jackson.version>
-        <mockito-core.version>2.11.0</mockito-core.version>
-        <junit-dataprovider.version>1.13.1</junit-dataprovider.version>
         <maven-surefire-plugin.version>2.20</maven-surefire-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-cobertura-plugin.version>2.7</maven-cobertura-plugin.version>
@@ -49,6 +35,7 @@
         <module>random-beans-jodatime</module>
         <module>random-beans-randomizers</module>
         <module>random-beans-bom</module>
+        <module>random-beans-parent</module>
     </modules>
 
     <scm>
@@ -177,93 +164,6 @@
             <url>https://github.com/VanOvermeire</url>
         </contributor>
     </contributors>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.github.benas</groupId>
-                <artifactId>random-beans</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.github.benas</groupId>
-                <artifactId>random-beans-randomizers</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>${validation-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${joda-time.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-context</artifactId>
-                <version>${spring-context.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.objenesis</groupId>
-                <artifactId>objenesis</artifactId>
-                <version>${objenesis.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.github.lukehutch</groupId>
-                <artifactId>fast-classpath-scanner</artifactId>
-                <version>${fast-classpath-scanner.version}</version>
-                <optional>true</optional>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-validator</artifactId>
-                <version>${hibernate-validator.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.web</groupId>
-                <artifactId>javax.el</artifactId>
-                <version>${javax.el.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.javafaker</groupId>
-                <artifactId>javafaker</artifactId>
-                <version>${faker.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>${assertj.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito-core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.tngtech.java</groupId>
-                <artifactId>junit-dataprovider</artifactId>
-                <version>${junit-dataprovider.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,10 @@
             <name>Sam Van Overmeire</name>
             <url>https://github.com/VanOvermeire</url>
         </contributor>
+        <contributor>
+            <name>Michael Düsterhus</name>
+            <url>https://github.com/reitzmichnicht</url>
+        </contributor>
     </contributors>
 
     <build>

--- a/random-beans-bom/pom.xml
+++ b/random-beans-bom/pom.xml
@@ -6,7 +6,7 @@
 
     <parent>
         <groupId>io.github.benas</groupId>
-        <artifactId>random-beans-parent</artifactId>
+        <artifactId>random-beans-project</artifactId>
         <version>3.8.0-SNAPSHOT</version>
     </parent>
 
@@ -14,134 +14,6 @@
     <packaging>pom</packaging>
     <name>Random Beans BOM</name>
     <description>Bill Of Materials for Random Beans library</description>
-    <url>https://github.com/benas/random-beans</url>
-
-    <scm>
-        <url>git@github.com:benas/random-beans.git</url>
-        <connection>scm:git:git@github.com:benas/random-beans.git</connection>
-        <developerConnection>scm:git:git@github.com:benas/random-beans.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
-    <ciManagement>
-        <system>Travis CI</system>
-        <url>https://travis-ci.org/benas/random-beans</url>
-    </ciManagement>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/benas/random-beans/issues</url>
-    </issueManagement>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/mit-license.php</url>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>benas</id>
-            <name>Mahmoud Ben Hassine</name>
-            <url>http://benas.github.io</url>
-            <email>mahmoud.benhassine@icloud.com</email>
-            <roles>
-                <role>Lead developer</role>
-            </roles>
-        </developer>
-        <developer>
-            <id>PascalSchumacher</id>
-            <name>Pascal Schumacher</name>
-            <url>https://github.com/PascalSchumacher</url>
-            <roles>
-                <role>Core developer</role>
-            </roles>
-        </developer>
-    </developers>
-
-    <contributors>
-        <contributor>
-            <name>Alberto Lagna</name>
-            <url>https://github.com/alagna</url>
-        </contributor>
-        <contributor>
-            <name>Adriano Machado</name>
-            <url>https://github.com/ammachado</url>
-        </contributor>
-        <contributor>
-            <name>Jose Manuel Prieto</name>
-            <url>https://github.com/prietopa</url>
-        </contributor>
-        <contributor>
-            <name>Eric Taix</name>
-            <url>https://github.com/eric-taix</url>
-        </contributor>
-        <contributor>
-            <name>Nikola Milivojevic</name>
-            <url>https://github.com/dziga</url>
-        </contributor>
-        <contributor>
-            <name>Oleksandr Shcherbyna</name>
-            <url>https://github.com/sansherbina</url>
-        </contributor>
-        <contributor>
-            <name>Rémi Alvergnat</name>
-            <url>http://www.pragmasphere.com</url>
-        </contributor>
-        <contributor>
-            <name>Rodrigue Alcazar</name>
-            <url>https://github.com/rodriguealcazar</url>
-        </contributor>
-        <contributor>
-            <name>Fred Eckertson</name>
-            <url>https://github.com/feckertson</url>
-        </contributor>
-        <contributor>
-            <name>Rebecca McQuary</name>
-            <url>https://github.com/rmcquary</url>
-        </contributor>
-        <contributor>
-            <name>Vincent Potucek</name>
-            <url>https://github.com/punkratz312</url>
-        </contributor>
-        <contributor>
-            <name>Dovid Kopel</name>
-            <url>https://github.com/dovidkopel</url>
-        </contributor>
-        <contributor>
-            <name>Valters Vingolds</name>
-            <url>https://github.com/valters</url>
-        </contributor>
-        <contributor>
-            <name>kermit-the-frog</name>
-            <url>https://github.com/kermit-the-frog</url>
-        </contributor>
-        <contributor>
-            <name>Lucas Andersson</name>
-            <url>https://github.com/LucasAndersson</url>
-        </contributor>
-        <contributor>
-            <name>euZebe</name>
-            <url>https://github.com/euzebe</url>
-        </contributor>
-        <contributor>
-            <name>Petromir Dzhunev</name>
-            <url>https://github.com/petromir</url>
-        </contributor>
-        <contributor>
-            <name>de-x</name>
-            <url>http://huningd.github.io</url>
-        </contributor>
-        <contributor>
-            <name>Ryan Dunckel</name>
-            <url>https://github.com/sparty02</url>
-        </contributor>
-        <contributor>
-            <name>Sam Van Overmeire</name>
-            <url>https://github.com/VanOvermeire</url>
-        </contributor>
-    </contributors>
 
     <dependencyManagement>
         <dependencies>

--- a/random-beans-jodatime/pom.xml
+++ b/random-beans-jodatime/pom.xml
@@ -10,43 +10,6 @@
     <name>Random Beans Joda Time</name>
     <artifactId>random-beans-jodatime</artifactId>
     <description>Random Beans module for Joda Time types support</description>
-    <url>https://github.com/benas/random-beans</url>
-
-    <scm>
-        <url>git@github.com:benas/random-beans.git</url>
-        <connection>scm:git:git@github.com:benas/random-beans.git</connection>
-        <developerConnection>scm:git:git@github.com:benas/random-beans.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
-    <ciManagement>
-        <system>Travis CI</system>
-        <url>https://travis-ci.org/benas/random-beans</url>
-    </ciManagement>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/benas/random-beans/issues</url>
-    </issueManagement>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/mit-license.php</url>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>benas</id>
-            <name>Mahmoud Ben Hassine</name>
-            <url>http://benas.github.io</url>
-            <email>mahmoud.benhassine@icloud.com</email>
-            <roles>
-                <role>Lead developer</role>
-            </roles>
-        </developer>
-    </developers>
 
     <dependencies>
         <dependency>

--- a/random-beans-jodatime/pom.xml
+++ b/random-beans-jodatime/pom.xml
@@ -4,6 +4,7 @@
         <artifactId>random-beans-parent</artifactId>
         <groupId>io.github.benas</groupId>
         <version>3.8.0-SNAPSHOT</version>
+        <relativePath>../random-beans-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/random-beans-parent/pom.xml
+++ b/random-beans-parent/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.github.benas</groupId>
+    <artifactId>random-beans-project</artifactId>
+    <version>3.8.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>io.github.benas</groupId>
+  <artifactId>random-beans-parent</artifactId>
+  <version>3.8.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Random Beans Parent</name>
+  <description>Random Beans parent for dependency management</description>
+
+  <properties>
+    <lombok.version>1.16.18</lombok.version>
+    <junit.version>4.12</junit.version>
+    <faker.version>0.14</faker.version>
+    <assertj.version>3.8.0</assertj.version>
+    <validation-api.version>1.1.0.Final</validation-api.version>
+    <joda-time.version>2.9.9</joda-time.version>
+    <spring-context.version>4.3.10.RELEASE</spring-context.version>
+    <objenesis.version>2.6</objenesis.version>
+    <fast-classpath-scanner.version>2.7.5</fast-classpath-scanner.version>
+    <hibernate-validator.version>5.4.1.Final</hibernate-validator.version>
+    <javax.el.version>2.2.6</javax.el.version>
+    <jackson.version>2.9.2</jackson.version>
+    <mockito-core.version>2.11.0</mockito-core.version>
+    <junit-dataprovider.version>1.13.1</junit-dataprovider.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.github.benas</groupId>
+        <artifactId>random-beans</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.benas</groupId>
+        <artifactId>random-beans-randomizers</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>javax.validation</groupId>
+        <artifactId>validation-api</artifactId>
+        <version>${validation-api.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>joda-time</groupId>
+        <artifactId>joda-time</artifactId>
+        <version>${joda-time.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <version>${spring-context.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>${objenesis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.lukehutch</groupId>
+        <artifactId>fast-classpath-scanner</artifactId>
+        <version>${fast-classpath-scanner.version}</version>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-validator</artifactId>
+        <version>${hibernate-validator.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.web</groupId>
+        <artifactId>javax.el</artifactId>
+        <version>${javax.el.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.javafaker</groupId>
+        <artifactId>javafaker</artifactId>
+        <version>${faker.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito-core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.tngtech.java</groupId>
+        <artifactId>junit-dataprovider</artifactId>
+        <version>${junit-dataprovider.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/random-beans-randomizers/pom.xml
+++ b/random-beans-randomizers/pom.xml
@@ -10,43 +10,6 @@
     <name>Random Beans Randomizers</name>
     <artifactId>random-beans-randomizers</artifactId>
     <description>Random Beans built-in randomizers</description>
-    <url>https://github.com/benas/random-beans</url>
-
-    <scm>
-        <url>git@github.com:benas/random-beans.git</url>
-        <connection>scm:git:git@github.com:benas/random-beans.git</connection>
-        <developerConnection>scm:git:git@github.com:benas/random-beans.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
-    <ciManagement>
-        <system>Travis CI</system>
-        <url>https://travis-ci.org/benas/random-beans</url>
-    </ciManagement>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/benas/random-beans/issues</url>
-    </issueManagement>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/mit-license.php</url>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>benas</id>
-            <name>Mahmoud Ben Hassine</name>
-            <url>http://benas.github.io</url>
-            <email>mahmoud.benhassine@icloud.com</email>
-            <roles>
-                <role>Lead developer</role>
-            </roles>
-        </developer>
-    </developers>
 
     <dependencies>
         <dependency>

--- a/random-beans-randomizers/pom.xml
+++ b/random-beans-randomizers/pom.xml
@@ -4,6 +4,7 @@
         <artifactId>random-beans-parent</artifactId>
         <groupId>io.github.benas</groupId>
         <version>3.8.0-SNAPSHOT</version>
+        <relativePath>../random-beans-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/Ipv4AddressRandomizer.java
+++ b/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/Ipv4AddressRandomizer.java
@@ -1,0 +1,80 @@
+package io.github.benas.randombeans.randomizers;
+
+import java.util.Locale;
+
+import io.github.benas.randombeans.api.Randomizer;
+
+/**
+ * A {@link Randomizer} that generates random IPv4 addresses.
+ *
+ * @author Michael Düsterhus
+ */
+public class Ipv4AddressRandomizer extends FakerBasedRandomizer<String> {
+
+	/**
+	 * Create a new {@link Ipv4AddressRandomizer}.
+	 */
+	public Ipv4AddressRandomizer() {
+	}
+
+	/**
+	 * Create a new {@link Ipv4AddressRandomizer}.
+	 *
+	 * @param seed
+	 *          the initial seed
+	 */
+	public Ipv4AddressRandomizer(long seed) {
+		super(seed);
+	}
+
+	/**
+	 * Create a new {@link Ipv4AddressRandomizer}.
+	 *
+	 * @param seed
+	 *          the initial seed
+	 * @param locale
+	 *          the locale to use
+	 */
+	public Ipv4AddressRandomizer(final long seed, final Locale locale) {
+		super(seed, locale);
+	}
+
+	/**
+	 * Create a new {@link Ipv4AddressRandomizer}.
+	 *
+	 * @return a new {@link Ipv4AddressRandomizer}
+	 */
+	public static Ipv4AddressRandomizer aNewIpv4AddressRandomizer() {
+		return new Ipv4AddressRandomizer();
+	}
+
+	/**
+	 * Create a new {@link Ipv4AddressRandomizer}.
+	 *
+	 * @param seed
+	 *          the initial seed
+	 * @return a new {@link Ipv4AddressRandomizer}
+	 */
+	public static Ipv4AddressRandomizer aNewIpv4AddressRandomizer(final long seed) {
+		return new Ipv4AddressRandomizer(seed);
+	}
+
+	/**
+	 * Create a new {@link Ipv4AddressRandomizer}.
+	 *
+	 * @param seed
+	 *          the initial seed
+	 * @param locale
+	 *          the locale to use
+	 * @return a new {@link Ipv4AddressRandomizer}
+	 */
+	public static Ipv4AddressRandomizer aNewIpv4AddressRandomizer(final long seed, final Locale locale) {
+		return new Ipv4AddressRandomizer(seed, locale);
+	}
+
+	@Override
+	public String getRandomValue() {
+		return faker.internet().ipV4Address();
+	}
+
+}

--- a/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/Ipv4AddressRandomizer.java
+++ b/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/Ipv4AddressRandomizer.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License
+ *
+ *   Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
 package io.github.benas.randombeans.randomizers;
 
 import java.util.Locale;

--- a/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/MacAddressRandomizer.java
+++ b/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/MacAddressRandomizer.java
@@ -1,0 +1,80 @@
+package io.github.benas.randombeans.randomizers;
+
+import java.util.Locale;
+
+import io.github.benas.randombeans.api.Randomizer;
+
+/**
+ * A {@link Randomizer} that generates random mac addresses.
+ *
+ * @author Michael Düsterhus
+ */
+public class MacAddressRandomizer extends FakerBasedRandomizer<String> {
+
+	/**
+	 * Create a new {@link MacAddressRandomizer}.
+	 */
+	public MacAddressRandomizer() {
+	}
+
+	/**
+	 * Create a new {@link MacAddressRandomizer}.
+	 *
+	 * @param seed
+	 *          the initial seed
+	 */
+	public MacAddressRandomizer(long seed) {
+		super(seed);
+	}
+
+	/**
+	 * Create a new {@link MacAddressRandomizer}.
+	 *
+	 * @param seed
+	 *          the initial seed
+	 * @param locale
+	 *          the locale to use
+	 */
+	public MacAddressRandomizer(final long seed, final Locale locale) {
+		super(seed, locale);
+	}
+
+	/**
+	 * Create a new {@link MacAddressRandomizer}.
+	 *
+	 * @return a new {@link MacAddressRandomizer}
+	 */
+	public static MacAddressRandomizer aNewMacAddressRandomizer() {
+		return new MacAddressRandomizer();
+	}
+
+	/**
+	 * Create a new {@link MacAddressRandomizer}.
+	 *
+	 * @param seed
+	 *          the initial seed
+	 * @return a new {@link MacAddressRandomizer}
+	 */
+	public static MacAddressRandomizer aNewMacAddressRandomizer(final long seed) {
+		return new MacAddressRandomizer(seed);
+	}
+
+	/**
+	 * Create a new {@link MacAddressRandomizer}.
+	 *
+	 * @param seed
+	 *          the initial seed
+	 * @param locale
+	 *          the locale to use
+	 * @return a new {@link MacAddressRandomizer}
+	 */
+	public static MacAddressRandomizer aNewMacAddressRandomizer(final long seed, final Locale locale) {
+		return new MacAddressRandomizer(seed, locale);
+	}
+
+	@Override
+	public String getRandomValue() {
+		return faker.internet().macAddress();
+	}
+
+}

--- a/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/MacAddressRandomizer.java
+++ b/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/MacAddressRandomizer.java
@@ -1,3 +1,26 @@
+/**
+ * The MIT License
+ *
+ *   Copyright (c) 2017, Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
 package io.github.benas.randombeans.randomizers;
 
 import java.util.Locale;

--- a/random-beans-randomizers/src/test/java/io/github/benas/randombeans/randomizers/RandomizersTest.java
+++ b/random-beans-randomizers/src/test/java/io/github/benas/randombeans/randomizers/RandomizersTest.java
@@ -30,10 +30,12 @@ import static io.github.benas.randombeans.randomizers.CreditCardNumberRandomizer
 import static io.github.benas.randombeans.randomizers.EmailRandomizer.aNewEmailRandomizer;
 import static io.github.benas.randombeans.randomizers.FirstNameRandomizer.aNewFirstNameRandomizer;
 import static io.github.benas.randombeans.randomizers.FullNameRandomizer.aNewFullNameRandomizer;
+import static io.github.benas.randombeans.randomizers.Ipv4AddressRandomizer.aNewIpv4AddressRandomizer;
 import static io.github.benas.randombeans.randomizers.IsbnRandomizer.aNewIsbnRandomizer;
 import static io.github.benas.randombeans.randomizers.LastNameRandomizer.aNewLastNameRandomizer;
 import static io.github.benas.randombeans.randomizers.LatitudeRandomizer.aNewLatitudeRandomizer;
 import static io.github.benas.randombeans.randomizers.LongitudeRandomizer.aNewLongitudeRandomizer;
+import static io.github.benas.randombeans.randomizers.MacAddressRandomizer.aNewMacAddressRandomizer;
 import static io.github.benas.randombeans.randomizers.ParagraphRandomizer.aNewParagraphRandomizer;
 import static io.github.benas.randombeans.randomizers.PhoneNumberRandomizer.aNewPhoneNumberRandomizer;
 import static io.github.benas.randombeans.randomizers.RegularExpressionRandomizer.aNewRegularExpressionRandomizer;
@@ -68,10 +70,12 @@ public class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer
                 aNewEmailRandomizer(),
                 aNewFirstNameRandomizer(),
                 aNewFullNameRandomizer(),
+                aNewIpv4AddressRandomizer(),
                 aNewIsbnRandomizer(),
                 aNewLastNameRandomizer(),
                 aNewLatitudeRandomizer(),
                 aNewLongitudeRandomizer(),
+                aNewMacAddressRandomizer(),
                 aNewPhoneNumberRandomizer(),
                 aNewRegularExpressionRandomizer("\\d+[A-Z]{5}"),
                 aNewParagraphRandomizer(),
@@ -102,10 +106,12 @@ public class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer
                 { aNewEmailRandomizer(SEED), "jayne.weissnat@hotmail.com" }, 
                 { aNewFirstNameRandomizer(SEED), "Jayne" },
                 { aNewFullNameRandomizer(SEED), "Candace Crona" },
+                { aNewIpv4AddressRandomizer(SEED), "16.188.76.229" },
                 { aNewIsbnRandomizer(SEED), "9781797845005" },
                 { aNewLastNameRandomizer(SEED), "Hyatt" },
                 { aNewLatitudeRandomizer(SEED), "40" + new DecimalFormatSymbols().getDecimalSeparator() + "171357" },
                 { aNewLongitudeRandomizer(SEED), "80" + new DecimalFormatSymbols().getDecimalSeparator() + "342713" },
+                { aNewMacAddressRandomizer(SEED), "b3:f4:49:94:c9:e8" },
                 { aNewParagraphRandomizer(SEED), "Totam assumenda eius autem similique. Aut voluptatem enim praesentium. Suscipit cupiditate doloribus debitis dolor. Cumque sapiente occaecati. Quos maiores quae." },
                 { aNewPhoneNumberRandomizer(SEED), "1-069-574-7539" },
                 { aNewRegularExpressionRandomizer("\\d+[A-Z]{5}", SEED), "8UYSMT" },
@@ -136,10 +142,12 @@ public class RandomizersTest extends AbstractRandomizerTest<FakerBasedRandomizer
                 { aNewEmailRandomizer(SEED, LOCALE), "alice.masson@hotmail.fr" }, 
                 { aNewFirstNameRandomizer(SEED, LOCALE), "Alice" },
                 { aNewFullNameRandomizer(SEED, LOCALE), "Masson Emilie" },
+                { aNewIpv4AddressRandomizer(SEED, LOCALE), "16.188.76.229" },
                 { aNewIsbnRandomizer(SEED, LOCALE), "9781797845005" },
                 { aNewLastNameRandomizer(SEED, LOCALE), "Faure" },
                 { aNewLatitudeRandomizer(SEED, LOCALE), "40" + new DecimalFormatSymbols().getDecimalSeparator() + "171357" }, // should really be "40.171357", seems like a bug in java-faker
                 { aNewLongitudeRandomizer(SEED, LOCALE), "80" + new DecimalFormatSymbols().getDecimalSeparator() + "342713" }, // should really be "80.342713", seems like a bug in java-faker
+                { aNewMacAddressRandomizer(SEED, LOCALE), "b3:f4:49:94:c9:e8" },
                 { aNewParagraphRandomizer(SEED, LOCALE), "Totam assumenda eius autem similique. Aut voluptatem enim praesentium. Suscipit cupiditate doloribus debitis dolor. Cumque sapiente occaecati. Quos maiores quae." },
                 { aNewPhoneNumberRandomizer(SEED, LOCALE), "03 06 95 74 75" },
                 { aNewSentenceRandomizer(SEED, LOCALE), "Dolor totam assumenda eius autem." },

--- a/random-beans-spring/pom.xml
+++ b/random-beans-spring/pom.xml
@@ -10,43 +10,6 @@
     <name>Random Beans Spring</name>
     <artifactId>random-beans-spring</artifactId>
     <description>Random Beans module for Spring support</description>
-    <url>https://github.com/benas/random-beans</url>
-
-    <scm>
-        <url>git@github.com:benas/random-beans.git</url>
-        <connection>scm:git:git@github.com:benas/random-beans.git</connection>
-        <developerConnection>scm:git:git@github.com:benas/random-beans.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
-    <ciManagement>
-        <system>Travis CI</system>
-        <url>https://travis-ci.org/benas/random-beans</url>
-    </ciManagement>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/benas/random-beans/issues</url>
-    </issueManagement>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/mit-license.php</url>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>benas</id>
-            <name>Mahmoud Ben Hassine</name>
-            <url>http://benas.github.io</url>
-            <email>mahmoud.benhassine@icloud.com</email>
-            <roles>
-                <role>Lead developer</role>
-            </roles>
-        </developer>
-    </developers>
 
     <dependencies>
         <dependency>
@@ -73,6 +36,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/random-beans-spring/pom.xml
+++ b/random-beans-spring/pom.xml
@@ -4,6 +4,7 @@
         <artifactId>random-beans-parent</artifactId>
         <groupId>io.github.benas</groupId>
         <version>3.8.0-SNAPSHOT</version>
+        <relativePath>../random-beans-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/random-beans-validation/pom.xml
+++ b/random-beans-validation/pom.xml
@@ -10,43 +10,6 @@
     <name>Random Beans Validation</name>
     <artifactId>random-beans-validation</artifactId>
     <description>Random Beans module for Bean Validation API support</description>
-    <url>https://github.com/benas/random-beans</url>
-
-    <scm>
-        <url>git@github.com:benas/random-beans.git</url>
-        <connection>scm:git:git@github.com:benas/random-beans.git</connection>
-        <developerConnection>scm:git:git@github.com:benas/random-beans.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
-    <ciManagement>
-        <system>Travis CI</system>
-        <url>https://travis-ci.org/benas/random-beans</url>
-    </ciManagement>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/benas/random-beans/issues</url>
-    </issueManagement>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/mit-license.php</url>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>benas</id>
-            <name>Mahmoud Ben Hassine</name>
-            <url>http://benas.github.io</url>
-            <email>mahmoud.benhassine@icloud.com</email>
-            <roles>
-                <role>Lead developer</role>
-            </roles>
-        </developer>
-    </developers>
 
     <dependencies>
         <dependency>

--- a/random-beans-validation/pom.xml
+++ b/random-beans-validation/pom.xml
@@ -4,6 +4,7 @@
         <artifactId>random-beans-parent</artifactId>
         <groupId>io.github.benas</groupId>
         <version>3.8.0-SNAPSHOT</version>
+        <relativePath>../random-beans-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/random-beans/pom.xml
+++ b/random-beans/pom.xml
@@ -12,42 +12,6 @@
     <description>Random Beans core implementation</description>
     <url>https://github.com/benas/random-beans</url>
 
-    <scm>
-        <url>git@github.com:benas/random-beans.git</url>
-        <connection>scm:git:git@github.com:benas/random-beans.git</connection>
-        <developerConnection>scm:git:git@github.com:benas/random-beans.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
-    <ciManagement>
-        <system>Travis CI</system>
-        <url>https://travis-ci.org/benas/random-beans</url>
-    </ciManagement>
-
-    <issueManagement>
-        <system>GitHub</system>
-        <url>https://github.com/benas/random-beans/issues</url>
-    </issueManagement>
-
-    <licenses>
-        <license>
-            <name>MIT License</name>
-            <url>http://opensource.org/licenses/mit-license.php</url>
-        </license>
-    </licenses>
-
-    <developers>
-        <developer>
-            <id>benas</id>
-            <name>Mahmoud Ben Hassine</name>
-            <url>http://benas.github.io</url>
-            <email>mahmoud.benhassine@icloud.com</email>
-            <roles>
-                <role>Lead developer</role>
-            </roles>
-        </developer>
-    </developers>
-
     <dependencies>
         <dependency>
             <groupId>org.objenesis</groupId>

--- a/random-beans/pom.xml
+++ b/random-beans/pom.xml
@@ -4,6 +4,7 @@
         <artifactId>random-beans-parent</artifactId>
         <groupId>io.github.benas</groupId>
         <version>3.8.0-SNAPSHOT</version>
+        <relativePath>../random-beans-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
I splitted parent pom into project and parent pom to separate the dependencyManagement section.
This is the common way to introduce a BOM.

Fixes #249