### PR TITLE
Add support for field name pattern

### DIFF
--- a/random-beans/src/main/java/io/github/benas/randombeans/FieldDefinition.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/FieldDefinition.java
@@ -28,6 +28,7 @@ import lombok.Value;
 import java.lang.annotation.Annotation;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Defines attributes used to identify fields.
@@ -39,7 +40,7 @@ import java.util.Set;
 @Value
 public class FieldDefinition<T, F> {
 
-    private final String name;
+    private final Predicate<String> namePattern;
 
     private final Class<F> type;
 
@@ -52,37 +53,37 @@ public class FieldDefinition<T, F> {
     /**
      * Create a new {@link FieldDefinition}.
      *
-     * @param name  the field name
-     * @param type  the filed type
+     * @param namePattern  to match field name
+     * @param type  the field type
      * @param clazz the declaring class type
      */
-    public FieldDefinition(String name, Class<F> type, Class<T> clazz) {
-        this(name, type, clazz, new HashSet<>());
+    public FieldDefinition(Predicate<String> namePattern, Class<F> type, Class<T> clazz) {
+        this(namePattern, type, clazz, new HashSet<>());
     }
 
     /**
      * Create a new {@link FieldDefinition}.
      *
-     * @param name  the field name
-     * @param type  the filed type
+     * @param namePattern  to match field name
+     * @param type  the field type
      * @param clazz the declaring class type
      * @param annotations annotations present on the field
      */
-    public FieldDefinition(String name, Class<F> type, Class<T> clazz, Set<Class <? extends Annotation>> annotations) {
-        this(name, type, clazz, annotations, null);
+    public FieldDefinition(Predicate<String> namePattern, Class<F> type, Class<T> clazz, Set<Class <? extends Annotation>> annotations) {
+        this(namePattern, type, clazz, annotations, null);
     }
 
     /**
      * Create a new {@link FieldDefinition}.
      *
-     * @param name  the field name
-     * @param type  the filed type
+     * @param namePattern  to match field name
+     * @param type  the field type
      * @param clazz the declaring class type
      * @param annotations annotations present on the field
      * @param modifiers the field modifiers
      */
-    public FieldDefinition(String name, Class<F> type, Class<T> clazz, Set<Class <? extends Annotation>> annotations, Integer modifiers) {
-        this.name = name;
+    public FieldDefinition(Predicate<String> namePattern, Class<F> type, Class<T> clazz, Set<Class <? extends Annotation>> annotations, Integer modifiers) {
+        this.namePattern = namePattern;
         this.type = type;
         this.clazz = clazz;
         this.annotations = annotations;

--- a/random-beans/src/main/java/io/github/benas/randombeans/FieldDefinitionBuilder.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/FieldDefinitionBuilder.java
@@ -27,6 +27,7 @@ import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Builder for {@link FieldDefinition}.
@@ -36,6 +37,8 @@ import java.util.Set;
 public class FieldDefinitionBuilder {
 
     private String name;
+
+    private Predicate<String> namingPattern;
 
     private Class<?> type;
 
@@ -62,6 +65,19 @@ public class FieldDefinitionBuilder {
      */
     public FieldDefinitionBuilder named(String name) {
         this.name = name;
+        return this;
+    }
+
+    /**
+     * Specify the pattern for field name.
+     *
+     * Taken into account only when name is not set
+     *
+     * @param patternName to match field name
+     * @return the configured {@link FieldDefinitionBuilder}
+     */
+    public FieldDefinitionBuilder namingPattern(Predicate<String> patternName) {
+        this.namingPattern = patternName;
         return this;
     }
 
@@ -116,7 +132,11 @@ public class FieldDefinitionBuilder {
      * @return a new {@link FieldDefinition}
      */
     public FieldDefinition<?, ?> get() {
-        return new FieldDefinition<>(name, type, clazz, annotations, modifiers);
+        return new FieldDefinition<>(getNamingPattern(), type, clazz, annotations, modifiers);
+    }
+
+    private Predicate<String> getNamingPattern() {
+        return (name != null) ? s -> name.equals(s) : namingPattern;
     }
 
 }

--- a/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/AbstractRandomizerRegistry.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/AbstractRandomizerRegistry.java
@@ -26,6 +26,7 @@ package io.github.benas.randombeans.randomizers.registry;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Base class for randomizer registries.
@@ -51,14 +52,14 @@ public class AbstractRandomizerRegistry {
     }
 
     /**
-     * Check if a {@code field} has the given {@code name}.
+     * Check if a {@code field} matches given {@code namePattern}.
      *
      * @param field to check
-     * @param name of the field
-     * @return true if the field has the given name, false otherwise
+     * @param namePattern to match
+     * @return true if matches given pattern, false otherwise
      */
-    protected boolean hasName(final Field field, final String name) {
-        return name == null || field.getName().equals(name);
+    protected boolean matches(final Field field, final Predicate<String> namePattern) {
+        return namePattern == null || namePattern.test(field.getName());
     }
 
     /**

--- a/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/CustomRandomizerRegistry.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/CustomRandomizerRegistry.java
@@ -53,7 +53,7 @@ public class CustomRandomizerRegistry extends AbstractRandomizerRegistry impleme
     @Override
     public Randomizer<?> getRandomizer(Field field) {
         for (FieldDefinition<?, ?> fieldDefinition : customFieldRandomizersRegistry.keySet()) {
-            if (hasName(field, fieldDefinition.getName()) &&
+            if (matches(field, fieldDefinition.getNamePattern()) &&
                     isDeclaredInClass(field, fieldDefinition.getClazz()) &&
                     hasType(field, fieldDefinition.getType()) &&
                     isAnnotatedWithOneOf(field, fieldDefinition.getAnnotations()) &&

--- a/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/ExclusionRandomizerRegistry.java
+++ b/random-beans/src/main/java/io/github/benas/randombeans/randomizers/registry/ExclusionRandomizerRegistry.java
@@ -61,7 +61,7 @@ public class ExclusionRandomizerRegistry extends AbstractRandomizerRegistry impl
     @Override
     public Randomizer<?> getRandomizer(Field field) {
         for (FieldDefinition<?, ?> fieldDefinition : fieldDefinitions) {
-            if (hasName(field, fieldDefinition.getName()) &&
+            if (matches(field, fieldDefinition.getNamePattern()) &&
                     isDeclaredInClass(field, fieldDefinition.getClazz()) &&
                     hasType(field, fieldDefinition.getType()) &&
                     isAnnotatedWithOneOf(field, fieldDefinition.getAnnotations()) &&

--- a/random-beans/src/test/java/io/github/benas/randombeans/FieldExclusionTest.java
+++ b/random-beans/src/test/java/io/github/benas/randombeans/FieldExclusionTest.java
@@ -275,7 +275,7 @@ public class FieldExclusionTest {
     @Test
     public void whenFieldIsExcluded_thenItsInlineInitializationShouldBeUsedAsIs() {
         enhancedRandom = aNewEnhancedRandomBuilder()
-            .exclude(new FieldDefinition<>("myList", List.class, InlineInitializationBean.class))
+            .exclude(new FieldDefinition<>("myList"::equals, List.class, InlineInitializationBean.class))
             .build();
 
         InlineInitializationBean bean = enhancedRandom.nextObject(InlineInitializationBean.class);
@@ -287,7 +287,7 @@ public class FieldExclusionTest {
     @Test
     public void whenFieldIsExcluded_thenItsInlineInitializationShouldBeUsedAsIs_EvenIfBeanHasNoPublicConstructor() {
         enhancedRandom = aNewEnhancedRandomBuilder()
-            .exclude(new FieldDefinition<>("myList", List.class, InlineInitializationBeanPrivateConstructor.class))
+            .exclude(new FieldDefinition<>("myList"::equals, List.class, InlineInitializationBeanPrivateConstructor.class))
             .build();
 
         InlineInitializationBeanPrivateConstructor bean = enhancedRandom.nextObject(InlineInitializationBeanPrivateConstructor.class);


### PR DESCRIPTION
Hi,
Change is simple, allow to build field definitions using patterns.

I work with many large schemas that has many plain Strings fields. Random mess in each of these doesn't look good as example data. There is a lot of different context IDs, names, etc. Sadly as mentioned I can't differentiate these by type.

I could list them by hand but it would be way easier to use generic regex for them.

Tests are green, most impacted are FieldDefinition constructors, on the other hand FieldDefinitionBuilder still allow to build definitions old way.

:)