### PR TITLE
Fix regular expressions randomizer - regexp with both leading and tailing boundary matchers

### DIFF
--- a/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/RegularExpressionRandomizer.java
+++ b/random-beans-randomizers/src/main/java/io/github/benas/randombeans/randomizers/RegularExpressionRandomizer.java
@@ -84,6 +84,7 @@ public class RegularExpressionRandomizer extends FakerBasedRandomizer<String> {
         int lastIndex = regularExpressionWithoutBoundaryMatchers.length() - 1;
         if (regularExpressionWithoutBoundaryMatchers.indexOf('^') == 0) {
             regularExpressionWithoutBoundaryMatchers = regularExpressionWithoutBoundaryMatchers.substring(1, lastIndex + 1);
+            lastIndex = regularExpressionWithoutBoundaryMatchers.length() - 1;
         }
         if (regularExpressionWithoutBoundaryMatchers.lastIndexOf('$') == lastIndex) {
             regularExpressionWithoutBoundaryMatchers = regularExpressionWithoutBoundaryMatchers.substring(0, lastIndex);

--- a/random-beans-randomizers/src/test/java/io/github/benas/randombeans/randomizers/RegularExpressionRandomizerTest.java
+++ b/random-beans-randomizers/src/test/java/io/github/benas/randombeans/randomizers/RegularExpressionRandomizerTest.java
@@ -50,4 +50,15 @@ public class RegularExpressionRandomizerTest {
 
         then(actual).isEqualTo("A");
     }
+
+    @Test
+    public void leadingAndTailingBoundaryMatcherIsRemoved() {
+        //given
+        RegularExpressionRandomizer randomizer = new RegularExpressionRandomizer("^A$");
+
+        //when
+        String actual = randomizer.getRandomValue();
+
+        then(actual).isEqualTo("A");
+    }
 }


### PR DESCRIPTION
When there are both ^ and $ boundary matchers in the regexp pattern, the tailing matcher $ is not removed. This PR fixes the issue and adds a test that is checking this case.