### PR TITLE
Bean validation: Add support for @PastOrPresent and @FutureOrPresent

### DIFF
--- a/random-beans-validation/src/main/java/io/github/benas/randombeans/validation/BeanValidationRandomizerRegistry.java
+++ b/random-beans-validation/src/main/java/io/github/benas/randombeans/validation/BeanValidationRandomizerRegistry.java
@@ -54,6 +54,7 @@ public class BeanValidationRandomizerRegistry implements RandomizerRegistry {
         annotationHandlers.put(AssertTrue.class, new AssertTrueAnnotationHandler());
         annotationHandlers.put(Null.class, new NullAnnotationHandler());
         annotationHandlers.put(Future.class, new FutureAnnotationHandler(seed));
+        annotationHandlers.put(FutureOrPresent.class, new FutureAnnotationHandler(seed));
         annotationHandlers.put(Past.class, new PastAnnotationHandler(seed));
         annotationHandlers.put(PastOrPresent.class, new PastAnnotationHandler(seed));
         annotationHandlers.put(Min.class, new MinMaxAnnotationHandler(seed));

--- a/random-beans-validation/src/main/java/io/github/benas/randombeans/validation/BeanValidationRandomizerRegistry.java
+++ b/random-beans-validation/src/main/java/io/github/benas/randombeans/validation/BeanValidationRandomizerRegistry.java
@@ -55,6 +55,7 @@ public class BeanValidationRandomizerRegistry implements RandomizerRegistry {
         annotationHandlers.put(Null.class, new NullAnnotationHandler());
         annotationHandlers.put(Future.class, new FutureAnnotationHandler(seed));
         annotationHandlers.put(Past.class, new PastAnnotationHandler(seed));
+        annotationHandlers.put(PastOrPresent.class, new PastAnnotationHandler(seed));
         annotationHandlers.put(Min.class, new MinMaxAnnotationHandler(seed));
         annotationHandlers.put(Max.class, new MinMaxAnnotationHandler(seed));
         annotationHandlers.put(DecimalMin.class, new DecimalMinMaxAnnotationHandler(seed));

--- a/random-beans-validation/src/test/java/io/github/benas/randombeans/validation/BeanValidationAnnotatedBean.java
+++ b/random-beans-validation/src/test/java/io/github/benas/randombeans/validation/BeanValidationAnnotatedBean.java
@@ -52,6 +52,9 @@ class BeanValidationAnnotatedBean {
     @Future
     private LocalDateTime eventLocalDateTime;
 
+    @FutureOrPresent
+    private Date futureOrPresent;
+
     @Past
     private Date birthday;
 
@@ -142,6 +145,10 @@ class BeanValidationAnnotatedBean {
 
     public LocalDateTime getEventLocalDateTime() {
         return eventLocalDateTime;
+    }
+
+    public Date getFutureOrPresent() {
+        return futureOrPresent;
     }
 
     public Date getBirthday() {

--- a/random-beans-validation/src/test/java/io/github/benas/randombeans/validation/BeanValidationAnnotatedBean.java
+++ b/random-beans-validation/src/test/java/io/github/benas/randombeans/validation/BeanValidationAnnotatedBean.java
@@ -58,6 +58,9 @@ class BeanValidationAnnotatedBean {
     @Past
     private LocalDateTime birthdayLocalDateTime;
 
+    @PastOrPresent
+    private Date pastOrPresent;
+
     @Max(10)
     private int maxQuantity;
 
@@ -151,6 +154,10 @@ class BeanValidationAnnotatedBean {
 
     public LocalDateTime getBirthdayLocalDateTime() {
         return birthdayLocalDateTime;
+    }
+
+    public Date getPastOrPresent() {
+        return pastOrPresent;
     }
 
     public int getMaxQuantity() {

--- a/random-beans-validation/src/test/java/io/github/benas/randombeans/validation/BeanValidationTest.java
+++ b/random-beans-validation/src/test/java/io/github/benas/randombeans/validation/BeanValidationTest.java
@@ -75,6 +75,8 @@ public class BeanValidationTest {
 
         assertThat(bean.getEventLocalDateTime()).isAfter(LocalDateTime.now());// @Future LocalDateTime eventLocalDateTime;
 
+        assertThat(bean.getFutureOrPresent()).isAfterOrEqualsTo(new Date());// @FutureOrPresent Date eventDate;
+
         assertThat(bean.getPositive()).isGreaterThan(0);// @Positive int positive;
 
         assertThat(bean.getPositiveOrZero()).isGreaterThanOrEqualTo(0);// @PositiveOrZero int positiveOrZero;

--- a/random-beans-validation/src/test/java/io/github/benas/randombeans/validation/BeanValidationTest.java
+++ b/random-beans-validation/src/test/java/io/github/benas/randombeans/validation/BeanValidationTest.java
@@ -28,6 +28,7 @@ import static io.github.benas.randombeans.EnhancedRandomBuilder.aNewEnhancedRand
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.util.Date;
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -67,6 +68,8 @@ public class BeanValidationTest {
         assertThat(bean.getBirthday()).isInThePast();// @Past Date birthday;
 
         assertThat(bean.getBirthdayLocalDateTime()).isBefore(LocalDateTime.now());// @Past LocalDateTime birthdayLocalDateTime;
+
+        assertThat(bean.getPastOrPresent()).isBeforeOrEqualsTo(new Date());// @PastOrPresent Date pastOrPresent;
 
         assertThat(bean.getEventDate()).isInTheFuture();// @Future Date eventDate;
 


### PR DESCRIPTION
Strictly speaking `PastAnnotationHandler` should be renamed to `PastOrPresentAnnotationHandler` (range: minDate (inclusive) to now (inclusive). `FutureAnnotationHandler` should be renamed to `FutureOrPresentAnnotationHandler` (range: now (inclusive) to maxDate (inclusive)).